### PR TITLE
Log the render time

### DIFF
--- a/create-release.sh
+++ b/create-release.sh
@@ -19,6 +19,7 @@ git pull > /dev/null
 echo "Whats the version number associated with this release? Type the version number followed by [enter]. "
 read VERSION
 
+npm version $VERSION
 git checkout master > /dev/null
 git pull > /dev/null
 git rebase develop > /dev/null

--- a/migrations/20160705120249.sql
+++ b/migrations/20160705120249.sql
@@ -1,0 +1,1 @@
+ALTER TABLE images ADD COLUMN rendered_at TIMESTAMPTZ default null;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iaas",
-  "version": "0.1.0",
+  "version": "0.1.3",
   "description": "ImageMagick as a HTTP service, using AWS S3 to store caches",
   "main": "src/index.js",
   "dependencies": {

--- a/src/dbCache.js
+++ b/src/dbCache.js
@@ -1,6 +1,6 @@
 import log from "./log";
 
-const insertImage = 'INSERT INTO images (id, x, y, fit, file_type, url, blur) VALUES ($1,$2,$3,$4,$5,$6,$7)';
+const insertImage = 'INSERT INTO images (id, x, y, fit, file_type, url, blur, rendered_at) VALUES ($1,$2,$3,$4,$5,$6,$7,$8)';
 const selectImage = 'SELECT url FROM images WHERE id=$1 AND x=$2 AND y=$3 AND fit=$4 AND file_type=$5 AND blur=$6';
 
 export default (db) => {
@@ -37,7 +37,8 @@ export default (db) => {
         params.fit,
         params.mime,
         url,
-        Boolean(params.blur)
+        Boolean(params.blur),
+        new Date()
       ];
 
       try {

--- a/src/index.js
+++ b/src/index.js
@@ -40,7 +40,7 @@ const uploadImage = async(req, res) => {
   const name = req.params.name;
   log('info', `Requested image upload for image_id ${name} with token ${sentToken}`);
 
-  const canConsumeToken = token(db).consume(sentToken, name);
+  const canConsumeToken = await token(db).consume(sentToken, name);
   if (!canConsumeToken) {
     res.status(403).end();
     return;


### PR DESCRIPTION
This will include the render time in the `images` table. That way it will allow us to purge any caches which were rendered incorrectly due to a bug.

Flyby: Additionally fix an async/await which missed the await

@wouter-willems ready for review!