### PR TITLE
Cache redirect less aggressively

### DIFF
--- a/src/helper.js
+++ b/src/helper.js
@@ -1,6 +1,6 @@
 export function futureDate() {
   const cacheDate = new Date();
-  cacheDate.setFullYear(cacheDate.getFullYear() + 10);
+  cacheDate.setMonth(cacheDate.getMonth() + 1);
   return cacheDate;
 }
 

--- a/src/helper.js
+++ b/src/helper.js
@@ -1,6 +1,6 @@
 export function futureDate() {
   const cacheDate = new Date();
-  cacheDate.setMonth(cacheDate.getMonth() + 1);
+  cacheDate.setFullYear(cacheDate.getFullYear() + 10);
   return cacheDate;
 }
 

--- a/src/imageResponse.js
+++ b/src/imageResponse.js
@@ -56,16 +56,16 @@ const redirectImageToWithinBounds = (params, response) => {
 };
 
 const redirectToCachedEntity = (cacheUrl, params, response) => {
+  // We redirect the user to the new location. The 307 ensures future requests come in to this service anyway
+  // 307 redirects are not cached by browsers
   response.status(307).set({
-    'Location': cacheUrl,
-    'Cache-Control': 'public',
-    'Expires': futureDate()
+    'Location': cacheUrl
   }).end();
   response.end();
 };
 
 const sendFoundHeaders = (params, response) => {
-  // Get the image and resize it
+  // Get the image and resize it. We allow any intermediate servers and browsers to use this cached resource as well
   response.status(200).type(params.mime).set({
     'Expires': futureDate(),
     'Cache-Control': 'public'
@@ -95,9 +95,11 @@ export default {
       return;
     }
 
-    // Image exists and is within bounds
+    // Image exists and is within bounds.
+    // This method is mainly used by browsers to serve retina images
     if (isHeadRequest(method)) {
       response.status(200).end();
+      log('info', `HEAD request for ${params.name}.${params.type} (${params.width}x${params.height}px, fit: ${params.fit}, blur: ${Boolean(params.blur)}) can be served`);  //eslint-disable-line max-len
       return;
     }
     log('info', `Request for ${params.name}.${params.type} (${params.width}x${params.height}px, fit: ${params.fit}, blur: ${Boolean(params.blur)})`);  //eslint-disable-line max-len

--- a/src/imageResponse.js
+++ b/src/imageResponse.js
@@ -59,7 +59,7 @@ const redirectToCachedEntity = (cacheUrl, params, response) => {
   response.status(307).set({
     'Location': cacheUrl,
     'Cache-Control': 'public',
-    'Expires': futureDate
+    'Expires': futureDate()
   }).end();
   response.end();
 };


### PR DESCRIPTION
<img width="442" alt="screenshot 2016-07-07 18 13 31" src="https://cloud.githubusercontent.com/assets/2778689/16660432/897a5e8a-446e-11e6-8a6c-d59bf11dcd35.png">

Slightly sad moment :\

Additionally I reduced the cache time a bit, since it allows us to prune caches easier

@TiddoLangerak @wouter-willems @joostverdoorn ready for review