### PR TITLE
Move interlacing to the end

### DIFF
--- a/src/image.js
+++ b/src/image.js
@@ -88,9 +88,9 @@ const blur = async(client, params) => {
 export default {
   magic: async function (file, params) {
     let client = im(file);
-    client = await interlace(client, params);
     client = await fit(client, params);
     client = await blur(client, params);
+    client = await interlace(client, params);
     return client;
   },
   writeOriented: async function (source, destination, cropParameters) {


### PR DESCRIPTION
It seems that interlacing gets lost with certain operations, such as
cropping. Moving interlacing to the end makes sure the final image is
interlaced.

For #80

Note: I haven't tested this with `iaas` itself yet, since I don't have the entire postgres installation setup (and no time to do it now), but I have verified this behaviour with CLI imagemagick. @rogierslag do we already have a ready made docker instance to test this with, or do I still need to setup postgres & configs myself?