### PR TITLE
Try to fix the docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:5.3
+FROM node:6
 MAINTAINER Rogier Slag
 
 RUN apt-get update && \
@@ -30,4 +30,4 @@ RUN cd /opt/iaas/src && babel -d ../ *.js
 
 # Run the entire thing!
 WORKDIR /opt/iaas
-CMD ["/usr/local/bin/pm2", "start", "index.js", "--no-daemon", "--instances=1"]
+CMD ["/usr/local/bin/pm2", "start", "index.js", "--no-daemon", "--instances=3"]

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -25,7 +25,7 @@
             "isarray": {
               "version": "1.0.0",
               "from": "isarray@>=1.0.0 <2.0.0",
-              "resolved": "http://npm.internal.magnet.me:4873/isarray/-/isarray-1.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
             }
           }
         },
@@ -42,7 +42,7 @@
         "querystring": {
           "version": "0.2.0",
           "from": "querystring@0.2.0",
-          "resolved": "http://npm.internal.magnet.me:4873/querystring/-/querystring-0.2.0.tgz"
+          "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
         },
         "sax": {
           "version": "1.1.5",
@@ -57,14 +57,14 @@
             "punycode": {
               "version": "1.3.2",
               "from": "punycode@1.3.2",
-              "resolved": "http://npm.internal.magnet.me:4873/punycode/-/punycode-1.3.2.tgz"
+              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
             }
           }
         },
         "uuid": {
           "version": "3.0.0",
           "from": "uuid@3.0.0",
-          "resolved": "http://npm.internal.magnet.me:4873/uuid/-/uuid-3.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.0.tgz"
         },
         "xml2js": {
           "version": "0.4.15",
@@ -88,7 +88,7 @@
     "babel-polyfill": {
       "version": "6.20.0",
       "from": "babel-polyfill@>=6.13.0 <7.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/babel-polyfill/-/babel-polyfill-6.20.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.20.0.tgz",
       "dependencies": {
         "core-js": {
           "version": "2.4.1",
@@ -97,13 +97,13 @@
         },
         "babel-runtime": {
           "version": "6.20.0",
-          "from": "babel-runtime@>=6.20.0 <7.0.0",
-          "resolved": "http://npm.internal.magnet.me:4873/babel-runtime/-/babel-runtime-6.20.0.tgz"
+          "from": "babel-runtime@>=6.9.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz"
         },
         "regenerator-runtime": {
           "version": "0.10.1",
           "from": "regenerator-runtime@>=0.10.0 <0.11.0",
-          "resolved": "http://npm.internal.magnet.me:4873/regenerator-runtime/-/regenerator-runtime-0.10.1.tgz"
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.1.tgz"
         }
       }
     },
@@ -125,12 +125,12 @@
         "debug": {
           "version": "2.2.0",
           "from": "debug@>=2.2.0 <2.3.0",
-          "resolved": "http://npm.internal.magnet.me:4873/debug/-/debug-2.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "dependencies": {
             "ms": {
               "version": "0.7.1",
               "from": "ms@0.7.1",
-              "resolved": "http://npm.internal.magnet.me:4873/ms/-/ms-0.7.1.tgz"
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
             }
           }
         },
@@ -142,7 +142,7 @@
         "http-errors": {
           "version": "1.5.1",
           "from": "http-errors@>=1.5.0 <1.6.0",
-          "resolved": "http://npm.internal.magnet.me:4873/http-errors/-/http-errors-1.5.1.tgz",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.1.tgz",
           "dependencies": {
             "inherits": {
               "version": "2.0.3",
@@ -152,11 +152,11 @@
             "setprototypeof": {
               "version": "1.0.2",
               "from": "setprototypeof@1.0.2",
-              "resolved": "http://npm.internal.magnet.me:4873/setprototypeof/-/setprototypeof-1.0.2.tgz"
+              "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.2.tgz"
             },
             "statuses": {
               "version": "1.3.1",
-              "from": "statuses@>=1.3.1 <2.0.0",
+              "from": "statuses@>=1.3.0 <1.4.0",
               "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
             }
           }
@@ -174,14 +174,14 @@
             "ee-first": {
               "version": "1.1.1",
               "from": "ee-first@1.1.1",
-              "resolved": "http://npm.internal.magnet.me:4873/ee-first/-/ee-first-1.1.1.tgz"
+              "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
             }
           }
         },
         "qs": {
           "version": "6.2.0",
           "from": "qs@6.2.0",
-          "resolved": "http://npm.internal.magnet.me:4873/qs/-/qs-6.2.0.tgz"
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz"
         },
         "raw-body": {
           "version": "2.1.7",
@@ -190,7 +190,7 @@
           "dependencies": {
             "unpipe": {
               "version": "1.0.0",
-              "from": "unpipe@1.0.0",
+              "from": "unpipe@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
             }
           }
@@ -198,22 +198,22 @@
         "type-is": {
           "version": "1.6.14",
           "from": "type-is@>=1.6.13 <1.7.0",
-          "resolved": "http://npm.internal.magnet.me:4873/type-is/-/type-is-1.6.14.tgz",
+          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.14.tgz",
           "dependencies": {
             "media-typer": {
               "version": "0.3.0",
               "from": "media-typer@0.3.0",
-              "resolved": "http://npm.internal.magnet.me:4873/media-typer/-/media-typer-0.3.0.tgz"
+              "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
             },
             "mime-types": {
               "version": "2.1.13",
               "from": "mime-types@>=2.1.13 <2.2.0",
-              "resolved": "http://npm.internal.magnet.me:4873/mime-types/-/mime-types-2.1.13.tgz",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
               "dependencies": {
                 "mime-db": {
                   "version": "1.25.0",
                   "from": "mime-db@>=1.25.0 <1.26.0",
-                  "resolved": "http://npm.internal.magnet.me:4873/mime-db/-/mime-db-1.25.0.tgz"
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz"
                 }
               }
             }
@@ -229,7 +229,7 @@
         "json5": {
           "version": "0.4.0",
           "from": "json5@0.4.0",
-          "resolved": "http://npm.internal.magnet.me:4873/json5/-/json5-0.4.0.tgz"
+          "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
         }
       }
     },
@@ -245,27 +245,27 @@
           "dependencies": {
             "mime-types": {
               "version": "2.1.13",
-              "from": "mime-types@>=2.1.11 <2.2.0",
-              "resolved": "http://npm.internal.magnet.me:4873/mime-types/-/mime-types-2.1.13.tgz",
+              "from": "mime-types@>=2.1.13 <2.2.0",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
               "dependencies": {
                 "mime-db": {
                   "version": "1.25.0",
                   "from": "mime-db@>=1.25.0 <1.26.0",
-                  "resolved": "http://npm.internal.magnet.me:4873/mime-db/-/mime-db-1.25.0.tgz"
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz"
                 }
               }
             },
             "negotiator": {
               "version": "0.6.1",
               "from": "negotiator@0.6.1",
-              "resolved": "http://npm.internal.magnet.me:4873/negotiator/-/negotiator-0.6.1.tgz"
+              "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz"
             }
           }
         },
         "array-flatten": {
           "version": "1.1.1",
           "from": "array-flatten@1.1.1",
-          "resolved": "http://npm.internal.magnet.me:4873/array-flatten/-/array-flatten-1.1.1.tgz"
+          "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz"
         },
         "content-disposition": {
           "version": "0.5.1",
@@ -285,17 +285,17 @@
         "cookie-signature": {
           "version": "1.0.6",
           "from": "cookie-signature@1.0.6",
-          "resolved": "http://npm.internal.magnet.me:4873/cookie-signature/-/cookie-signature-1.0.6.tgz"
+          "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
         },
         "debug": {
           "version": "2.2.0",
           "from": "debug@>=2.2.0 <2.3.0",
-          "resolved": "http://npm.internal.magnet.me:4873/debug/-/debug-2.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "dependencies": {
             "ms": {
               "version": "0.7.1",
               "from": "ms@0.7.1",
-              "resolved": "http://npm.internal.magnet.me:4873/ms/-/ms-0.7.1.tgz"
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
             }
           }
         },
@@ -339,12 +339,12 @@
         "fresh": {
           "version": "0.3.0",
           "from": "fresh@0.3.0",
-          "resolved": "http://npm.internal.magnet.me:4873/fresh/-/fresh-0.3.0.tgz"
+          "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz"
         },
         "merge-descriptors": {
           "version": "1.0.1",
           "from": "merge-descriptors@1.0.1",
-          "resolved": "http://npm.internal.magnet.me:4873/merge-descriptors/-/merge-descriptors-1.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz"
         },
         "methods": {
           "version": "1.1.2",
@@ -359,7 +359,7 @@
             "ee-first": {
               "version": "1.1.1",
               "from": "ee-first@1.1.1",
-              "resolved": "http://npm.internal.magnet.me:4873/ee-first/-/ee-first-1.1.1.tgz"
+              "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
             }
           }
         },
@@ -386,14 +386,14 @@
             "ipaddr.js": {
               "version": "1.1.1",
               "from": "ipaddr.js@1.1.1",
-              "resolved": "http://npm.internal.magnet.me:4873/ipaddr.js/-/ipaddr.js-1.1.1.tgz"
+              "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.1.1.tgz"
             }
           }
         },
         "qs": {
           "version": "6.2.0",
           "from": "qs@6.2.0",
-          "resolved": "http://npm.internal.magnet.me:4873/qs/-/qs-6.2.0.tgz"
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz"
         },
         "range-parser": {
           "version": "1.2.0",
@@ -413,7 +413,7 @@
             "http-errors": {
               "version": "1.5.1",
               "from": "http-errors@>=1.5.0 <1.6.0",
-              "resolved": "http://npm.internal.magnet.me:4873/http-errors/-/http-errors-1.5.1.tgz",
+              "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.1.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.3",
@@ -423,19 +423,19 @@
                 "setprototypeof": {
                   "version": "1.0.2",
                   "from": "setprototypeof@1.0.2",
-                  "resolved": "http://npm.internal.magnet.me:4873/setprototypeof/-/setprototypeof-1.0.2.tgz"
+                  "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.2.tgz"
                 }
               }
             },
             "mime": {
               "version": "1.3.4",
               "from": "mime@1.3.4",
-              "resolved": "http://npm.internal.magnet.me:4873/mime/-/mime-1.3.4.tgz"
+              "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
             },
             "ms": {
               "version": "0.7.1",
               "from": "ms@0.7.1",
-              "resolved": "http://npm.internal.magnet.me:4873/ms/-/ms-0.7.1.tgz"
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
             },
             "statuses": {
               "version": "1.3.1",
@@ -452,22 +452,22 @@
         "type-is": {
           "version": "1.6.14",
           "from": "type-is@>=1.6.13 <1.7.0",
-          "resolved": "http://npm.internal.magnet.me:4873/type-is/-/type-is-1.6.14.tgz",
+          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.14.tgz",
           "dependencies": {
             "media-typer": {
               "version": "0.3.0",
               "from": "media-typer@0.3.0",
-              "resolved": "http://npm.internal.magnet.me:4873/media-typer/-/media-typer-0.3.0.tgz"
+              "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
             },
             "mime-types": {
               "version": "2.1.13",
-              "from": "mime-types@>=2.1.11 <2.2.0",
-              "resolved": "http://npm.internal.magnet.me:4873/mime-types/-/mime-types-2.1.13.tgz",
+              "from": "mime-types@>=2.1.13 <2.2.0",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
               "dependencies": {
                 "mime-db": {
                   "version": "1.25.0",
                   "from": "mime-db@>=1.25.0 <1.26.0",
-                  "resolved": "http://npm.internal.magnet.me:4873/mime-db/-/mime-db-1.25.0.tgz"
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz"
                 }
               }
             }
@@ -513,17 +513,17 @@
             "lru-cache": {
               "version": "4.0.2",
               "from": "lru-cache@>=4.0.1 <5.0.0",
-              "resolved": "http://npm.internal.magnet.me:4873/lru-cache/-/lru-cache-4.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
               "dependencies": {
                 "pseudomap": {
                   "version": "1.0.2",
                   "from": "pseudomap@>=1.0.1 <2.0.0",
-                  "resolved": "http://npm.internal.magnet.me:4873/pseudomap/-/pseudomap-1.0.2.tgz"
+                  "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz"
                 },
                 "yallist": {
                   "version": "2.0.0",
                   "from": "yallist@>=2.0.0 <3.0.0",
-                  "resolved": "http://npm.internal.magnet.me:4873/yallist/-/yallist-2.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz"
                 }
               }
             },
@@ -535,7 +535,7 @@
                 "isexe": {
                   "version": "1.1.2",
                   "from": "isexe@>=1.1.1 <2.0.0",
-                  "resolved": "http://npm.internal.magnet.me:4873/isexe/-/isexe-1.1.2.tgz"
+                  "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz"
                 }
               }
             }
@@ -544,12 +544,12 @@
         "debug": {
           "version": "2.2.0",
           "from": "debug@>=2.2.0 <2.3.0",
-          "resolved": "http://npm.internal.magnet.me:4873/debug/-/debug-2.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "dependencies": {
             "ms": {
               "version": "0.7.1",
               "from": "ms@0.7.1",
-              "resolved": "http://npm.internal.magnet.me:4873/ms/-/ms-0.7.1.tgz"
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
             }
           }
         }
@@ -613,7 +613,7 @@
                 "xtend": {
                   "version": "4.0.1",
                   "from": "xtend@>=4.0.0 <5.0.0",
-                  "resolved": "http://npm.internal.magnet.me:4873/xtend/-/xtend-4.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                 }
               }
             }
@@ -632,7 +632,7 @@
                 "through": {
                   "version": "2.3.8",
                   "from": "through@>=2.0.0 <3.0.0",
-                  "resolved": "http://npm.internal.magnet.me:4873/through/-/through-2.3.8.tgz"
+                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
                 }
               }
             }
@@ -641,7 +641,7 @@
         "semver": {
           "version": "4.3.6",
           "from": "semver@>=4.1.0 <5.0.0",
-          "resolved": "http://npm.internal.magnet.me:4873/semver/-/semver-4.3.6.tgz"
+          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
         }
       }
     },
@@ -658,17 +658,17 @@
         "fs-extra": {
           "version": "0.26.7",
           "from": "fs-extra@>=0.26.4 <0.27.0",
-          "resolved": "http://npm.internal.magnet.me:4873/fs-extra/-/fs-extra-0.26.7.tgz",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz",
           "dependencies": {
             "graceful-fs": {
               "version": "4.1.11",
               "from": "graceful-fs@>=4.1.2 <5.0.0",
-              "resolved": "http://npm.internal.magnet.me:4873/graceful-fs/-/graceful-fs-4.1.11.tgz"
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
             },
             "jsonfile": {
               "version": "2.4.0",
               "from": "jsonfile@>=2.1.0 <3.0.0",
-              "resolved": "http://npm.internal.magnet.me:4873/jsonfile/-/jsonfile-2.4.0.tgz"
+              "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz"
             },
             "klaw": {
               "version": "1.3.1",
@@ -683,7 +683,7 @@
             "rimraf": {
               "version": "2.5.4",
               "from": "rimraf@>=2.2.8 <3.0.0",
-              "resolved": "http://npm.internal.magnet.me:4873/rimraf/-/rimraf-2.5.4.tgz",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
               "dependencies": {
                 "glob": {
                   "version": "7.1.1",
@@ -703,7 +703,7 @@
                         "wrappy": {
                           "version": "1.0.2",
                           "from": "wrappy@>=1.0.0 <2.0.0",
-                          "resolved": "http://npm.internal.magnet.me:4873/wrappy/-/wrappy-1.0.2.tgz"
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                         }
                       }
                     },
@@ -715,7 +715,7 @@
                     "minimatch": {
                       "version": "3.0.3",
                       "from": "minimatch@>=3.0.2 <4.0.0",
-                      "resolved": "http://npm.internal.magnet.me:4873/minimatch/-/minimatch-3.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.6",
@@ -730,7 +730,7 @@
                             "concat-map": {
                               "version": "0.0.1",
                               "from": "concat-map@0.0.1",
-                              "resolved": "http://npm.internal.magnet.me:4873/concat-map/-/concat-map-0.0.1.tgz"
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                             }
                           }
                         }
@@ -739,12 +739,12 @@
                     "once": {
                       "version": "1.4.0",
                       "from": "once@>=1.3.0 <2.0.0",
-                      "resolved": "http://npm.internal.magnet.me:4873/once/-/once-1.4.0.tgz",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.2",
                           "from": "wrappy@>=1.0.0 <2.0.0",
-                          "resolved": "http://npm.internal.magnet.me:4873/wrappy/-/wrappy-1.0.2.tgz"
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                         }
                       }
                     }
@@ -764,7 +764,7 @@
         "nodegit-promise": {
           "version": "4.0.0",
           "from": "nodegit-promise@>=4.0.0 <4.1.0",
-          "resolved": "http://npm.internal.magnet.me:4873/nodegit-promise/-/nodegit-promise-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/nodegit-promise/-/nodegit-promise-4.0.0.tgz",
           "dependencies": {
             "asap": {
               "version": "2.0.5",
@@ -776,7 +776,7 @@
         "object-assign": {
           "version": "4.1.0",
           "from": "object-assign@>=4.0.1 <5.0.0",
-          "resolved": "http://npm.internal.magnet.me:4873/object-assign/-/object-assign-4.1.0.tgz"
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
         }
       }
     },

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2,2906 +2,788 @@
   "name": "iaas",
   "version": "0.1.11",
   "dependencies": {
-    "accepts": {
-      "version": "1.3.3",
-      "from": "accepts@>=1.3.3 <1.4.0",
-      "resolved": "http://npm.internal.magnet.me:4873/accepts/-/accepts-1.3.3.tgz"
-    },
-    "acorn": {
-      "version": "3.2.0",
-      "from": "acorn@>=3.2.0 <4.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/acorn/-/acorn-3.2.0.tgz"
-    },
-    "acorn-jsx": {
-      "version": "3.0.1",
-      "from": "acorn-jsx@>=3.0.0 <4.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/acorn-jsx/-/acorn-jsx-3.0.1.tgz"
-    },
-    "amdefine": {
-      "version": "1.0.0",
-      "from": "amdefine@>=0.0.4",
-      "resolved": "http://npm.internal.magnet.me:4873/amdefine/-/amdefine-1.0.0.tgz"
-    },
-    "ansi-escapes": {
-      "version": "1.4.0",
-      "from": "ansi-escapes@>=1.1.0 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/ansi-escapes/-/ansi-escapes-1.4.0.tgz"
-    },
-    "ansi-regex": {
-      "version": "2.0.0",
-      "from": "ansi-regex@>=2.0.0 <3.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/ansi-regex/-/ansi-regex-2.0.0.tgz"
-    },
-    "ansi-styles": {
-      "version": "2.2.1",
-      "from": "ansi-styles@>=2.1.0 <3.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/ansi-styles/-/ansi-styles-2.2.1.tgz"
-    },
-    "anymatch": {
-      "version": "1.3.0",
-      "from": "anymatch@>=1.3.0 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/anymatch/-/anymatch-1.3.0.tgz"
-    },
-    "ap": {
-      "version": "0.2.0",
-      "from": "ap@>=0.2.0 <0.3.0",
-      "resolved": "http://npm.internal.magnet.me:4873/ap/-/ap-0.2.0.tgz"
-    },
-    "argparse": {
-      "version": "1.0.7",
-      "from": "argparse@>=1.0.7 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/argparse/-/argparse-1.0.7.tgz"
-    },
-    "arr-diff": {
-      "version": "2.0.0",
-      "from": "arr-diff@>=2.0.0 <3.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/arr-diff/-/arr-diff-2.0.0.tgz"
-    },
-    "arr-flatten": {
-      "version": "1.0.1",
-      "from": "arr-flatten@>=1.0.1 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/arr-flatten/-/arr-flatten-1.0.1.tgz"
-    },
-    "array-find-index": {
-      "version": "1.0.1",
-      "from": "array-find-index@>=1.0.1 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/array-find-index/-/array-find-index-1.0.1.tgz"
-    },
-    "array-flatten": {
-      "version": "1.1.1",
-      "from": "array-flatten@1.1.1",
-      "resolved": "http://npm.internal.magnet.me:4873/array-flatten/-/array-flatten-1.1.1.tgz"
-    },
-    "array-parallel": {
-      "version": "0.1.3",
-      "from": "array-parallel@>=0.1.3 <0.2.0",
-      "resolved": "http://npm.internal.magnet.me:4873/array-parallel/-/array-parallel-0.1.3.tgz"
-    },
-    "array-series": {
-      "version": "0.1.5",
-      "from": "array-series@>=0.1.5 <0.2.0",
-      "resolved": "http://npm.internal.magnet.me:4873/array-series/-/array-series-0.1.5.tgz"
-    },
-    "array-union": {
-      "version": "1.0.2",
-      "from": "array-union@>=1.0.1 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/array-union/-/array-union-1.0.2.tgz"
-    },
-    "array-uniq": {
-      "version": "1.0.3",
-      "from": "array-uniq@>=1.0.0 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/array-uniq/-/array-uniq-1.0.3.tgz"
-    },
-    "array-unique": {
-      "version": "0.2.1",
-      "from": "array-unique@>=0.2.1 <0.3.0",
-      "resolved": "http://npm.internal.magnet.me:4873/array-unique/-/array-unique-0.2.1.tgz"
-    },
-    "arrify": {
-      "version": "1.0.1",
-      "from": "arrify@>=1.0.0 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/arrify/-/arrify-1.0.1.tgz"
-    },
-    "asap": {
-      "version": "2.0.4",
-      "from": "asap@>=2.0.3 <2.1.0",
-      "resolved": "http://npm.internal.magnet.me:4873/asap/-/asap-2.0.4.tgz"
-    },
-    "asn1": {
-      "version": "0.2.3",
-      "from": "asn1@>=0.2.3 <0.3.0",
-      "resolved": "http://npm.internal.magnet.me:4873/asn1/-/asn1-0.2.3.tgz"
-    },
-    "assert-plus": {
-      "version": "0.2.0",
-      "from": "assert-plus@>=0.2.0 <0.3.0",
-      "resolved": "http://npm.internal.magnet.me:4873/assert-plus/-/assert-plus-0.2.0.tgz"
-    },
-    "async": {
-      "version": "1.5.2",
-      "from": "async@>=1.5.2 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/async/-/async-1.5.2.tgz"
-    },
-    "async-each": {
-      "version": "1.0.0",
-      "from": "async-each@>=1.0.0 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/async-each/-/async-each-1.0.0.tgz"
-    },
     "aws-sdk": {
-      "version": "2.4.4",
-      "from": "aws-sdk@>=2.2.26 <3.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/aws-sdk/-/aws-sdk-2.4.4.tgz"
-    },
-    "aws-sign2": {
-      "version": "0.6.0",
-      "from": "aws-sign2@>=0.6.0 <0.7.0",
-      "resolved": "http://npm.internal.magnet.me:4873/aws-sign2/-/aws-sign2-0.6.0.tgz"
-    },
-    "aws4": {
-      "version": "1.4.1",
-      "from": "aws4@>=1.2.1 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/aws4/-/aws4-1.4.1.tgz"
-    },
-    "babel-cli": {
-      "version": "6.10.1",
-      "from": "babel-cli@>=6.4.0 <7.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/babel-cli/-/babel-cli-6.10.1.tgz",
+      "version": "2.7.13",
+      "from": "aws-sdk@>=2.6.15 <3.0.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.7.13.tgz",
       "dependencies": {
-        "glob": {
-          "version": "5.0.15",
-          "from": "glob@>=5.0.5 <6.0.0",
-          "resolved": "http://npm.internal.magnet.me:4873/glob/-/glob-5.0.15.tgz"
+        "buffer": {
+          "version": "4.9.1",
+          "from": "buffer@4.9.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+          "dependencies": {
+            "base64-js": {
+              "version": "1.2.0",
+              "from": "base64-js@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.0.tgz"
+            },
+            "ieee754": {
+              "version": "1.1.8",
+              "from": "ieee754@>=1.1.4 <2.0.0",
+              "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz"
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "from": "isarray@>=1.0.0 <2.0.0",
+              "resolved": "http://npm.internal.magnet.me:4873/isarray/-/isarray-1.0.0.tgz"
+            }
+          }
         },
-        "lodash": {
-          "version": "4.13.1",
-          "from": "lodash@>=4.2.0 <5.0.0",
-          "resolved": "http://npm.internal.magnet.me:4873/lodash/-/lodash-4.13.1.tgz"
+        "crypto-browserify": {
+          "version": "1.0.9",
+          "from": "crypto-browserify@1.0.9",
+          "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-1.0.9.tgz"
+        },
+        "jmespath": {
+          "version": "0.15.0",
+          "from": "jmespath@0.15.0",
+          "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz"
+        },
+        "querystring": {
+          "version": "0.2.0",
+          "from": "querystring@0.2.0",
+          "resolved": "http://npm.internal.magnet.me:4873/querystring/-/querystring-0.2.0.tgz"
+        },
+        "sax": {
+          "version": "1.1.5",
+          "from": "sax@1.1.5",
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.5.tgz"
+        },
+        "url": {
+          "version": "0.10.3",
+          "from": "url@0.10.3",
+          "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+          "dependencies": {
+            "punycode": {
+              "version": "1.3.2",
+              "from": "punycode@1.3.2",
+              "resolved": "http://npm.internal.magnet.me:4873/punycode/-/punycode-1.3.2.tgz"
+            }
+          }
+        },
+        "uuid": {
+          "version": "3.0.0",
+          "from": "uuid@3.0.0",
+          "resolved": "http://npm.internal.magnet.me:4873/uuid/-/uuid-3.0.0.tgz"
+        },
+        "xml2js": {
+          "version": "0.4.15",
+          "from": "xml2js@0.4.15",
+          "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.15.tgz"
+        },
+        "xmlbuilder": {
+          "version": "2.6.2",
+          "from": "xmlbuilder@2.6.2",
+          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-2.6.2.tgz",
+          "dependencies": {
+            "lodash": {
+              "version": "3.5.0",
+              "from": "lodash@>=3.5.0 <3.6.0",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.5.0.tgz"
+            }
+          }
         }
       }
-    },
-    "babel-code-frame": {
-      "version": "6.11.0",
-      "from": "babel-code-frame@>=6.8.0 <7.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/babel-code-frame/-/babel-code-frame-6.11.0.tgz"
-    },
-    "babel-core": {
-      "version": "6.10.4",
-      "from": "babel-core@>=6.9.0 <7.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/babel-core/-/babel-core-6.10.4.tgz",
-      "dependencies": {
-        "lodash": {
-          "version": "4.13.1",
-          "from": "lodash@>=4.2.0 <5.0.0",
-          "resolved": "http://npm.internal.magnet.me:4873/lodash/-/lodash-4.13.1.tgz"
-        }
-      }
-    },
-    "babel-eslint": {
-      "version": "6.1.0",
-      "from": "babel-eslint@>=6.1.0 <7.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/babel-eslint/-/babel-eslint-6.1.0.tgz"
-    },
-    "babel-generator": {
-      "version": "6.11.0",
-      "from": "babel-generator@>=6.9.0 <7.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/babel-generator/-/babel-generator-6.11.0.tgz",
-      "dependencies": {
-        "lodash": {
-          "version": "4.13.1",
-          "from": "lodash@>=4.2.0 <5.0.0",
-          "resolved": "http://npm.internal.magnet.me:4873/lodash/-/lodash-4.13.1.tgz"
-        }
-      }
-    },
-    "babel-helper-builder-binary-assignment-operator-visitor": {
-      "version": "6.8.0",
-      "from": "babel-helper-builder-binary-assignment-operator-visitor@>=6.8.0 <7.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.8.0.tgz"
-    },
-    "babel-helper-call-delegate": {
-      "version": "6.8.0",
-      "from": "babel-helper-call-delegate@>=6.8.0 <7.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/babel-helper-call-delegate/-/babel-helper-call-delegate-6.8.0.tgz"
-    },
-    "babel-helper-define-map": {
-      "version": "6.9.0",
-      "from": "babel-helper-define-map@>=6.9.0 <7.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/babel-helper-define-map/-/babel-helper-define-map-6.9.0.tgz",
-      "dependencies": {
-        "lodash": {
-          "version": "4.13.1",
-          "from": "lodash@>=4.2.0 <5.0.0",
-          "resolved": "http://npm.internal.magnet.me:4873/lodash/-/lodash-4.13.1.tgz"
-        }
-      }
-    },
-    "babel-helper-explode-assignable-expression": {
-      "version": "6.8.0",
-      "from": "babel-helper-explode-assignable-expression@>=6.8.0 <7.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.8.0.tgz"
-    },
-    "babel-helper-function-name": {
-      "version": "6.8.0",
-      "from": "babel-helper-function-name@>=6.8.0 <7.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/babel-helper-function-name/-/babel-helper-function-name-6.8.0.tgz"
-    },
-    "babel-helper-get-function-arity": {
-      "version": "6.8.0",
-      "from": "babel-helper-get-function-arity@>=6.8.0 <7.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.8.0.tgz"
-    },
-    "babel-helper-hoist-variables": {
-      "version": "6.8.0",
-      "from": "babel-helper-hoist-variables@>=6.8.0 <7.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.8.0.tgz"
-    },
-    "babel-helper-optimise-call-expression": {
-      "version": "6.8.0",
-      "from": "babel-helper-optimise-call-expression@>=6.8.0 <7.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.8.0.tgz"
-    },
-    "babel-helper-regex": {
-      "version": "6.9.0",
-      "from": "babel-helper-regex@>=6.8.0 <7.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/babel-helper-regex/-/babel-helper-regex-6.9.0.tgz",
-      "dependencies": {
-        "lodash": {
-          "version": "4.13.1",
-          "from": "lodash@>=4.2.0 <5.0.0",
-          "resolved": "http://npm.internal.magnet.me:4873/lodash/-/lodash-4.13.1.tgz"
-        }
-      }
-    },
-    "babel-helper-remap-async-to-generator": {
-      "version": "6.11.2",
-      "from": "babel-helper-remap-async-to-generator@>=6.8.0 <7.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.11.2.tgz"
-    },
-    "babel-helper-replace-supers": {
-      "version": "6.8.0",
-      "from": "babel-helper-replace-supers@>=6.8.0 <7.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/babel-helper-replace-supers/-/babel-helper-replace-supers-6.8.0.tgz"
-    },
-    "babel-helpers": {
-      "version": "6.8.0",
-      "from": "babel-helpers@>=6.8.0 <7.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/babel-helpers/-/babel-helpers-6.8.0.tgz"
-    },
-    "babel-messages": {
-      "version": "6.8.0",
-      "from": "babel-messages@>=6.8.0 <7.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/babel-messages/-/babel-messages-6.8.0.tgz"
-    },
-    "babel-plugin-check-es2015-constants": {
-      "version": "6.8.0",
-      "from": "babel-plugin-check-es2015-constants@>=6.3.13 <7.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.8.0.tgz"
-    },
-    "babel-plugin-syntax-async-functions": {
-      "version": "6.8.0",
-      "from": "babel-plugin-syntax-async-functions@>=6.8.0 <7.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.8.0.tgz"
-    },
-    "babel-plugin-syntax-exponentiation-operator": {
-      "version": "6.8.0",
-      "from": "babel-plugin-syntax-exponentiation-operator@>=6.8.0 <7.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.8.0.tgz"
-    },
-    "babel-plugin-syntax-trailing-function-commas": {
-      "version": "6.8.0",
-      "from": "babel-plugin-syntax-trailing-function-commas@>=6.3.13 <7.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.8.0.tgz"
-    },
-    "babel-plugin-transform-async-to-generator": {
-      "version": "6.8.0",
-      "from": "babel-plugin-transform-async-to-generator@>=6.3.13 <7.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.8.0.tgz"
-    },
-    "babel-plugin-transform-es2015-arrow-functions": {
-      "version": "6.8.0",
-      "from": "babel-plugin-transform-es2015-arrow-functions@>=6.3.13 <7.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.8.0.tgz"
-    },
-    "babel-plugin-transform-es2015-block-scoped-functions": {
-      "version": "6.8.0",
-      "from": "babel-plugin-transform-es2015-block-scoped-functions@>=6.3.13 <7.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.8.0.tgz"
-    },
-    "babel-plugin-transform-es2015-block-scoping": {
-      "version": "6.10.1",
-      "from": "babel-plugin-transform-es2015-block-scoping@>=6.9.0 <7.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.10.1.tgz",
-      "dependencies": {
-        "lodash": {
-          "version": "4.13.1",
-          "from": "lodash@>=4.2.0 <5.0.0",
-          "resolved": "http://npm.internal.magnet.me:4873/lodash/-/lodash-4.13.1.tgz"
-        }
-      }
-    },
-    "babel-plugin-transform-es2015-classes": {
-      "version": "6.9.0",
-      "from": "babel-plugin-transform-es2015-classes@>=6.9.0 <7.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.9.0.tgz"
-    },
-    "babel-plugin-transform-es2015-computed-properties": {
-      "version": "6.8.0",
-      "from": "babel-plugin-transform-es2015-computed-properties@>=6.3.13 <7.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.8.0.tgz"
-    },
-    "babel-plugin-transform-es2015-destructuring": {
-      "version": "6.9.0",
-      "from": "babel-plugin-transform-es2015-destructuring@>=6.9.0 <7.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.9.0.tgz"
-    },
-    "babel-plugin-transform-es2015-duplicate-keys": {
-      "version": "6.8.0",
-      "from": "babel-plugin-transform-es2015-duplicate-keys@>=6.6.0 <7.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.8.0.tgz"
-    },
-    "babel-plugin-transform-es2015-for-of": {
-      "version": "6.8.0",
-      "from": "babel-plugin-transform-es2015-for-of@>=6.6.0 <7.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.8.0.tgz"
-    },
-    "babel-plugin-transform-es2015-function-name": {
-      "version": "6.9.0",
-      "from": "babel-plugin-transform-es2015-function-name@>=6.9.0 <7.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.9.0.tgz"
-    },
-    "babel-plugin-transform-es2015-literals": {
-      "version": "6.8.0",
-      "from": "babel-plugin-transform-es2015-literals@>=6.3.13 <7.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.8.0.tgz"
-    },
-    "babel-plugin-transform-es2015-modules-commonjs": {
-      "version": "6.10.3",
-      "from": "babel-plugin-transform-es2015-modules-commonjs@>=6.6.0 <7.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.10.3.tgz"
-    },
-    "babel-plugin-transform-es2015-object-super": {
-      "version": "6.8.0",
-      "from": "babel-plugin-transform-es2015-object-super@>=6.3.13 <7.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.8.0.tgz"
-    },
-    "babel-plugin-transform-es2015-parameters": {
-      "version": "6.9.0",
-      "from": "babel-plugin-transform-es2015-parameters@>=6.9.0 <7.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.9.0.tgz"
-    },
-    "babel-plugin-transform-es2015-shorthand-properties": {
-      "version": "6.8.0",
-      "from": "babel-plugin-transform-es2015-shorthand-properties@>=6.3.13 <7.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.8.0.tgz"
-    },
-    "babel-plugin-transform-es2015-spread": {
-      "version": "6.8.0",
-      "from": "babel-plugin-transform-es2015-spread@>=6.3.13 <7.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.8.0.tgz"
-    },
-    "babel-plugin-transform-es2015-sticky-regex": {
-      "version": "6.8.0",
-      "from": "babel-plugin-transform-es2015-sticky-regex@>=6.3.13 <7.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.8.0.tgz"
-    },
-    "babel-plugin-transform-es2015-template-literals": {
-      "version": "6.8.0",
-      "from": "babel-plugin-transform-es2015-template-literals@>=6.6.0 <7.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.8.0.tgz"
-    },
-    "babel-plugin-transform-es2015-typeof-symbol": {
-      "version": "6.8.0",
-      "from": "babel-plugin-transform-es2015-typeof-symbol@>=6.6.0 <7.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.8.0.tgz"
-    },
-    "babel-plugin-transform-es2015-unicode-regex": {
-      "version": "6.11.0",
-      "from": "babel-plugin-transform-es2015-unicode-regex@>=6.3.13 <7.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.11.0.tgz"
-    },
-    "babel-plugin-transform-exponentiation-operator": {
-      "version": "6.8.0",
-      "from": "babel-plugin-transform-exponentiation-operator@>=6.3.13 <7.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.8.0.tgz"
-    },
-    "babel-plugin-transform-regenerator": {
-      "version": "6.9.0",
-      "from": "babel-plugin-transform-regenerator@>=6.9.0 <7.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.9.0.tgz"
-    },
-    "babel-plugin-transform-strict-mode": {
-      "version": "6.8.0",
-      "from": "babel-plugin-transform-strict-mode@>=6.8.0 <7.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.8.0.tgz"
     },
     "babel-polyfill": {
-      "version": "6.9.1",
-      "from": "babel-polyfill@>=6.9.1 <7.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/babel-polyfill/-/babel-polyfill-6.9.1.tgz"
-    },
-    "babel-preset-es2015": {
-      "version": "6.9.0",
-      "from": "babel-preset-es2015@>=6.3.0 <7.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/babel-preset-es2015/-/babel-preset-es2015-6.9.0.tgz"
-    },
-    "babel-preset-stage-3": {
-      "version": "6.11.0",
-      "from": "babel-preset-stage-3@>=6.11.0 <7.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/babel-preset-stage-3/-/babel-preset-stage-3-6.11.0.tgz"
-    },
-    "babel-register": {
-      "version": "6.9.0",
-      "from": "babel-register@>=6.9.0 <7.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/babel-register/-/babel-register-6.9.0.tgz",
+      "version": "6.20.0",
+      "from": "babel-polyfill@>=6.13.0 <7.0.0",
+      "resolved": "http://npm.internal.magnet.me:4873/babel-polyfill/-/babel-polyfill-6.20.0.tgz",
       "dependencies": {
-        "lodash": {
-          "version": "4.13.1",
-          "from": "lodash@>=4.2.0 <5.0.0",
-          "resolved": "http://npm.internal.magnet.me:4873/lodash/-/lodash-4.13.1.tgz"
+        "core-js": {
+          "version": "2.4.1",
+          "from": "core-js@>=2.4.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+        },
+        "babel-runtime": {
+          "version": "6.20.0",
+          "from": "babel-runtime@>=6.20.0 <7.0.0",
+          "resolved": "http://npm.internal.magnet.me:4873/babel-runtime/-/babel-runtime-6.20.0.tgz"
+        },
+        "regenerator-runtime": {
+          "version": "0.10.1",
+          "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+          "resolved": "http://npm.internal.magnet.me:4873/regenerator-runtime/-/regenerator-runtime-0.10.1.tgz"
         }
       }
-    },
-    "babel-runtime": {
-      "version": "6.9.2",
-      "from": "babel-runtime@>=6.9.1 <7.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/babel-runtime/-/babel-runtime-6.9.2.tgz"
-    },
-    "babel-template": {
-      "version": "6.9.0",
-      "from": "babel-template@>=6.9.0 <7.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/babel-template/-/babel-template-6.9.0.tgz",
-      "dependencies": {
-        "lodash": {
-          "version": "4.13.1",
-          "from": "lodash@>=4.2.0 <5.0.0",
-          "resolved": "http://npm.internal.magnet.me:4873/lodash/-/lodash-4.13.1.tgz"
-        }
-      }
-    },
-    "babel-traverse": {
-      "version": "6.10.4",
-      "from": "babel-traverse@>=6.10.4 <7.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/babel-traverse/-/babel-traverse-6.10.4.tgz",
-      "dependencies": {
-        "lodash": {
-          "version": "4.13.1",
-          "from": "lodash@>=4.2.0 <5.0.0",
-          "resolved": "http://npm.internal.magnet.me:4873/lodash/-/lodash-4.13.1.tgz"
-        }
-      }
-    },
-    "babel-types": {
-      "version": "6.11.1",
-      "from": "babel-types@>=6.9.1 <7.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/babel-types/-/babel-types-6.11.1.tgz",
-      "dependencies": {
-        "lodash": {
-          "version": "4.13.1",
-          "from": "lodash@>=4.2.0 <5.0.0",
-          "resolved": "http://npm.internal.magnet.me:4873/lodash/-/lodash-4.13.1.tgz"
-        }
-      }
-    },
-    "babylon": {
-      "version": "6.8.2",
-      "from": "babylon@>=6.7.0 <7.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/babylon/-/babylon-6.8.2.tgz"
-    },
-    "balanced-match": {
-      "version": "0.4.1",
-      "from": "balanced-match@>=0.4.1 <0.5.0",
-      "resolved": "http://npm.internal.magnet.me:4873/balanced-match/-/balanced-match-0.4.1.tgz"
-    },
-    "bin-version": {
-      "version": "1.0.4",
-      "from": "bin-version@>=1.0.0 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/bin-version/-/bin-version-1.0.4.tgz"
-    },
-    "bin-version-check": {
-      "version": "2.1.0",
-      "from": "bin-version-check@>=2.1.0 <3.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/bin-version-check/-/bin-version-check-2.1.0.tgz"
-    },
-    "binary-extensions": {
-      "version": "1.5.0",
-      "from": "binary-extensions@>=1.0.0 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/binary-extensions/-/binary-extensions-1.5.0.tgz"
-    },
-    "bl": {
-      "version": "1.1.2",
-      "from": "bl@>=1.1.2 <1.2.0",
-      "resolved": "http://npm.internal.magnet.me:4873/bl/-/bl-1.1.2.tgz",
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.0.6",
-          "from": "readable-stream@>=2.0.5 <2.1.0",
-          "resolved": "http://npm.internal.magnet.me:4873/readable-stream/-/readable-stream-2.0.6.tgz"
-        }
-      }
-    },
-    "bluebird": {
-      "version": "3.4.1",
-      "from": "bluebird@>=3.1.1 <4.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/bluebird/-/bluebird-3.4.1.tgz"
     },
     "body-parser": {
       "version": "1.15.2",
-      "from": "body-parser@>=1.14.2 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/body-parser/-/body-parser-1.15.2.tgz"
-    },
-    "boom": {
-      "version": "2.10.1",
-      "from": "boom@>=2.0.0 <3.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/boom/-/boom-2.10.1.tgz"
-    },
-    "brace-expansion": {
-      "version": "1.1.5",
-      "from": "brace-expansion@>=1.0.0 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/brace-expansion/-/brace-expansion-1.1.5.tgz"
-    },
-    "braces": {
-      "version": "1.8.5",
-      "from": "braces@>=1.8.2 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/braces/-/braces-1.8.5.tgz"
-    },
-    "buffer-shims": {
-      "version": "1.0.0",
-      "from": "buffer-shims@>=1.0.0 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/buffer-shims/-/buffer-shims-1.0.0.tgz"
-    },
-    "buffer-writer": {
-      "version": "1.0.1",
-      "from": "buffer-writer@1.0.1",
-      "resolved": "http://npm.internal.magnet.me:4873/buffer-writer/-/buffer-writer-1.0.1.tgz"
-    },
-    "builtin-modules": {
-      "version": "1.1.1",
-      "from": "builtin-modules@>=1.0.0 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/builtin-modules/-/builtin-modules-1.1.1.tgz"
-    },
-    "bytes": {
-      "version": "2.4.0",
-      "from": "bytes@2.4.0",
-      "resolved": "http://npm.internal.magnet.me:4873/bytes/-/bytes-2.4.0.tgz"
-    },
-    "caller-path": {
-      "version": "0.1.0",
-      "from": "caller-path@>=0.1.0 <0.2.0",
-      "resolved": "http://npm.internal.magnet.me:4873/caller-path/-/caller-path-0.1.0.tgz"
-    },
-    "callsites": {
-      "version": "0.2.0",
-      "from": "callsites@>=0.2.0 <0.3.0",
-      "resolved": "http://npm.internal.magnet.me:4873/callsites/-/callsites-0.2.0.tgz"
-    },
-    "camelcase": {
-      "version": "2.1.1",
-      "from": "camelcase@>=2.0.0 <3.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/camelcase/-/camelcase-2.1.1.tgz"
-    },
-    "camelcase-keys": {
-      "version": "2.1.0",
-      "from": "camelcase-keys@>=2.0.0 <3.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/camelcase-keys/-/camelcase-keys-2.1.0.tgz"
-    },
-    "caseless": {
-      "version": "0.11.0",
-      "from": "caseless@>=0.11.0 <0.12.0",
-      "resolved": "http://npm.internal.magnet.me:4873/caseless/-/caseless-0.11.0.tgz"
-    },
-    "chalk": {
-      "version": "1.1.1",
-      "from": "chalk@1.1.1",
-      "resolved": "http://npm.internal.magnet.me:4873/chalk/-/chalk-1.1.1.tgz"
-    },
-    "chokidar": {
-      "version": "1.6.0",
-      "from": "chokidar@>=1.0.0 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/chokidar/-/chokidar-1.6.0.tgz"
-    },
-    "cli-cursor": {
-      "version": "1.0.2",
-      "from": "cli-cursor@>=1.0.1 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/cli-cursor/-/cli-cursor-1.0.2.tgz"
-    },
-    "cli-width": {
-      "version": "2.1.0",
-      "from": "cli-width@>=2.0.0 <3.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/cli-width/-/cli-width-2.1.0.tgz"
-    },
-    "code-point-at": {
-      "version": "1.0.0",
-      "from": "code-point-at@>=1.0.0 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/code-point-at/-/code-point-at-1.0.0.tgz"
-    },
-    "combined-stream": {
-      "version": "1.0.5",
-      "from": "combined-stream@>=1.0.5 <1.1.0",
-      "resolved": "http://npm.internal.magnet.me:4873/combined-stream/-/combined-stream-1.0.5.tgz"
-    },
-    "commander": {
-      "version": "2.9.0",
-      "from": "commander@>=2.8.1 <3.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/commander/-/commander-2.9.0.tgz"
-    },
-    "concat-map": {
-      "version": "0.0.1",
-      "from": "concat-map@0.0.1",
-      "resolved": "http://npm.internal.magnet.me:4873/concat-map/-/concat-map-0.0.1.tgz"
-    },
-    "concat-stream": {
-      "version": "1.5.1",
-      "from": "concat-stream@>=1.4.6 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/concat-stream/-/concat-stream-1.5.1.tgz",
+      "from": "body-parser@>=1.15.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.15.2.tgz",
       "dependencies": {
-        "readable-stream": {
-          "version": "2.0.6",
-          "from": "readable-stream@>=2.0.0 <2.1.0",
-          "resolved": "http://npm.internal.magnet.me:4873/readable-stream/-/readable-stream-2.0.6.tgz"
+        "bytes": {
+          "version": "2.4.0",
+          "from": "bytes@2.4.0",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz"
+        },
+        "content-type": {
+          "version": "1.0.2",
+          "from": "content-type@>=1.0.2 <1.1.0",
+          "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz"
+        },
+        "debug": {
+          "version": "2.2.0",
+          "from": "debug@>=2.2.0 <2.3.0",
+          "resolved": "http://npm.internal.magnet.me:4873/debug/-/debug-2.2.0.tgz",
+          "dependencies": {
+            "ms": {
+              "version": "0.7.1",
+              "from": "ms@0.7.1",
+              "resolved": "http://npm.internal.magnet.me:4873/ms/-/ms-0.7.1.tgz"
+            }
+          }
+        },
+        "depd": {
+          "version": "1.1.0",
+          "from": "depd@>=1.1.0 <1.2.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
+        },
+        "http-errors": {
+          "version": "1.5.1",
+          "from": "http-errors@>=1.5.0 <1.6.0",
+          "resolved": "http://npm.internal.magnet.me:4873/http-errors/-/http-errors-1.5.1.tgz",
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.3",
+              "from": "inherits@2.0.3",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+            },
+            "setprototypeof": {
+              "version": "1.0.2",
+              "from": "setprototypeof@1.0.2",
+              "resolved": "http://npm.internal.magnet.me:4873/setprototypeof/-/setprototypeof-1.0.2.tgz"
+            },
+            "statuses": {
+              "version": "1.3.1",
+              "from": "statuses@>=1.3.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
+            }
+          }
+        },
+        "iconv-lite": {
+          "version": "0.4.13",
+          "from": "iconv-lite@0.4.13",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
+        },
+        "on-finished": {
+          "version": "2.3.0",
+          "from": "on-finished@>=2.3.0 <2.4.0",
+          "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+          "dependencies": {
+            "ee-first": {
+              "version": "1.1.1",
+              "from": "ee-first@1.1.1",
+              "resolved": "http://npm.internal.magnet.me:4873/ee-first/-/ee-first-1.1.1.tgz"
+            }
+          }
+        },
+        "qs": {
+          "version": "6.2.0",
+          "from": "qs@6.2.0",
+          "resolved": "http://npm.internal.magnet.me:4873/qs/-/qs-6.2.0.tgz"
+        },
+        "raw-body": {
+          "version": "2.1.7",
+          "from": "raw-body@>=2.1.7 <2.2.0",
+          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.7.tgz",
+          "dependencies": {
+            "unpipe": {
+              "version": "1.0.0",
+              "from": "unpipe@1.0.0",
+              "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
+            }
+          }
+        },
+        "type-is": {
+          "version": "1.6.14",
+          "from": "type-is@>=1.6.13 <1.7.0",
+          "resolved": "http://npm.internal.magnet.me:4873/type-is/-/type-is-1.6.14.tgz",
+          "dependencies": {
+            "media-typer": {
+              "version": "0.3.0",
+              "from": "media-typer@0.3.0",
+              "resolved": "http://npm.internal.magnet.me:4873/media-typer/-/media-typer-0.3.0.tgz"
+            },
+            "mime-types": {
+              "version": "2.1.13",
+              "from": "mime-types@>=2.1.13 <2.2.0",
+              "resolved": "http://npm.internal.magnet.me:4873/mime-types/-/mime-types-2.1.13.tgz",
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.25.0",
+                  "from": "mime-db@>=1.25.0 <1.26.0",
+                  "resolved": "http://npm.internal.magnet.me:4873/mime-db/-/mime-db-1.25.0.tgz"
+                }
+              }
+            }
+          }
         }
       }
     },
     "config": {
-      "version": "1.21.0",
-      "from": "config@>=1.17.1 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/config/-/config-1.21.0.tgz"
-    },
-    "content-disposition": {
-      "version": "0.5.1",
-      "from": "content-disposition@0.5.1",
-      "resolved": "http://npm.internal.magnet.me:4873/content-disposition/-/content-disposition-0.5.1.tgz"
-    },
-    "content-type": {
-      "version": "1.0.2",
-      "from": "content-type@>=1.0.2 <1.1.0",
-      "resolved": "http://npm.internal.magnet.me:4873/content-type/-/content-type-1.0.2.tgz"
-    },
-    "convert-source-map": {
-      "version": "1.2.0",
-      "from": "convert-source-map@>=1.1.0 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/convert-source-map/-/convert-source-map-1.2.0.tgz"
-    },
-    "cookie": {
-      "version": "0.3.1",
-      "from": "cookie@0.3.1",
-      "resolved": "http://npm.internal.magnet.me:4873/cookie/-/cookie-0.3.1.tgz"
-    },
-    "cookie-signature": {
-      "version": "1.0.6",
-      "from": "cookie-signature@1.0.6",
-      "resolved": "http://npm.internal.magnet.me:4873/cookie-signature/-/cookie-signature-1.0.6.tgz"
-    },
-    "core-js": {
-      "version": "2.4.0",
-      "from": "core-js@>=2.4.0 <3.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/core-js/-/core-js-2.4.0.tgz"
-    },
-    "core-util-is": {
-      "version": "1.0.2",
-      "from": "core-util-is@>=1.0.0 <1.1.0",
-      "resolved": "http://npm.internal.magnet.me:4873/core-util-is/-/core-util-is-1.0.2.tgz"
-    },
-    "cryptiles": {
-      "version": "2.0.5",
-      "from": "cryptiles@>=2.0.0 <3.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/cryptiles/-/cryptiles-2.0.5.tgz"
-    },
-    "currently-unhandled": {
-      "version": "0.4.1",
-      "from": "currently-unhandled@>=0.4.1 <0.5.0",
-      "resolved": "http://npm.internal.magnet.me:4873/currently-unhandled/-/currently-unhandled-0.4.1.tgz"
-    },
-    "d": {
-      "version": "0.1.1",
-      "from": "d@>=0.1.1 <0.2.0",
-      "resolved": "http://npm.internal.magnet.me:4873/d/-/d-0.1.1.tgz"
-    },
-    "dashdash": {
-      "version": "1.14.0",
-      "from": "dashdash@>=1.12.0 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/dashdash/-/dashdash-1.14.0.tgz",
+      "version": "1.24.0",
+      "from": "config@>=1.24.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/config/-/config-1.24.0.tgz",
       "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "from": "assert-plus@>=1.0.0 <2.0.0",
-          "resolved": "http://npm.internal.magnet.me:4873/assert-plus/-/assert-plus-1.0.0.tgz"
+        "json5": {
+          "version": "0.4.0",
+          "from": "json5@0.4.0",
+          "resolved": "http://npm.internal.magnet.me:4873/json5/-/json5-0.4.0.tgz"
         }
       }
-    },
-    "debug": {
-      "version": "2.2.0",
-      "from": "debug@>=2.2.0 <2.3.0",
-      "resolved": "http://npm.internal.magnet.me:4873/debug/-/debug-2.2.0.tgz"
-    },
-    "decamelize": {
-      "version": "1.2.0",
-      "from": "decamelize@>=1.1.2 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/decamelize/-/decamelize-1.2.0.tgz"
-    },
-    "deep-is": {
-      "version": "0.1.3",
-      "from": "deep-is@>=0.1.3 <0.2.0",
-      "resolved": "http://npm.internal.magnet.me:4873/deep-is/-/deep-is-0.1.3.tgz"
-    },
-    "del": {
-      "version": "2.2.1",
-      "from": "del@>=2.0.2 <3.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/del/-/del-2.2.1.tgz"
-    },
-    "delayed-stream": {
-      "version": "1.0.0",
-      "from": "delayed-stream@>=1.0.0 <1.1.0",
-      "resolved": "http://npm.internal.magnet.me:4873/delayed-stream/-/delayed-stream-1.0.0.tgz"
-    },
-    "depd": {
-      "version": "1.1.0",
-      "from": "depd@>=1.1.0 <1.2.0",
-      "resolved": "http://npm.internal.magnet.me:4873/depd/-/depd-1.1.0.tgz"
-    },
-    "destroy": {
-      "version": "1.0.4",
-      "from": "destroy@>=1.0.4 <1.1.0",
-      "resolved": "http://npm.internal.magnet.me:4873/destroy/-/destroy-1.0.4.tgz"
-    },
-    "detect-indent": {
-      "version": "3.0.1",
-      "from": "detect-indent@>=3.0.1 <4.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/detect-indent/-/detect-indent-3.0.1.tgz"
-    },
-    "doctrine": {
-      "version": "1.2.2",
-      "from": "doctrine@>=1.2.2 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/doctrine/-/doctrine-1.2.2.tgz",
-      "dependencies": {
-        "esutils": {
-          "version": "1.1.6",
-          "from": "esutils@>=1.1.6 <2.0.0",
-          "resolved": "http://npm.internal.magnet.me:4873/esutils/-/esutils-1.1.6.tgz"
-        }
-      }
-    },
-    "ecc-jsbn": {
-      "version": "0.1.1",
-      "from": "ecc-jsbn@>=0.1.1 <0.2.0",
-      "resolved": "http://npm.internal.magnet.me:4873/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
-    },
-    "ee-first": {
-      "version": "1.1.1",
-      "from": "ee-first@1.1.1",
-      "resolved": "http://npm.internal.magnet.me:4873/ee-first/-/ee-first-1.1.1.tgz"
-    },
-    "encodeurl": {
-      "version": "1.0.1",
-      "from": "encodeurl@>=1.0.1 <1.1.0",
-      "resolved": "http://npm.internal.magnet.me:4873/encodeurl/-/encodeurl-1.0.1.tgz"
-    },
-    "error-ex": {
-      "version": "1.3.0",
-      "from": "error-ex@>=1.2.0 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/error-ex/-/error-ex-1.3.0.tgz"
-    },
-    "es5-ext": {
-      "version": "0.10.12",
-      "from": "es5-ext@>=0.10.11 <0.11.0",
-      "resolved": "http://npm.internal.magnet.me:4873/es5-ext/-/es5-ext-0.10.12.tgz"
-    },
-    "es6-iterator": {
-      "version": "2.0.0",
-      "from": "es6-iterator@>=2.0.0 <3.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/es6-iterator/-/es6-iterator-2.0.0.tgz"
-    },
-    "es6-map": {
-      "version": "0.1.4",
-      "from": "es6-map@>=0.1.3 <0.2.0",
-      "resolved": "http://npm.internal.magnet.me:4873/es6-map/-/es6-map-0.1.4.tgz"
-    },
-    "es6-promise": {
-      "version": "3.2.1",
-      "from": "es6-promise@>=3.0.2 <4.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/es6-promise/-/es6-promise-3.2.1.tgz"
-    },
-    "es6-set": {
-      "version": "0.1.4",
-      "from": "es6-set@>=0.1.3 <0.2.0",
-      "resolved": "http://npm.internal.magnet.me:4873/es6-set/-/es6-set-0.1.4.tgz"
-    },
-    "es6-symbol": {
-      "version": "3.1.0",
-      "from": "es6-symbol@>=3.1.0 <3.2.0",
-      "resolved": "http://npm.internal.magnet.me:4873/es6-symbol/-/es6-symbol-3.1.0.tgz"
-    },
-    "es6-weak-map": {
-      "version": "2.0.1",
-      "from": "es6-weak-map@>=2.0.1 <3.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/es6-weak-map/-/es6-weak-map-2.0.1.tgz"
-    },
-    "escape-html": {
-      "version": "1.0.3",
-      "from": "escape-html@>=1.0.3 <1.1.0",
-      "resolved": "http://npm.internal.magnet.me:4873/escape-html/-/escape-html-1.0.3.tgz"
-    },
-    "escape-string-regexp": {
-      "version": "1.0.5",
-      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-    },
-    "escope": {
-      "version": "3.6.0",
-      "from": "escope@>=3.6.0 <4.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/escope/-/escope-3.6.0.tgz"
-    },
-    "eslint": {
-      "version": "2.13.1",
-      "from": "eslint@>=2.13.1 <3.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/eslint/-/eslint-2.13.1.tgz",
-      "dependencies": {
-        "chalk": {
-          "version": "1.1.3",
-          "from": "chalk@>=1.1.3 <2.0.0",
-          "resolved": "http://npm.internal.magnet.me:4873/chalk/-/chalk-1.1.3.tgz"
-        },
-        "globals": {
-          "version": "9.8.0",
-          "from": "globals@>=9.2.0 <10.0.0",
-          "resolved": "http://npm.internal.magnet.me:4873/globals/-/globals-9.8.0.tgz"
-        },
-        "lodash": {
-          "version": "4.13.1",
-          "from": "lodash@>=4.0.0 <5.0.0",
-          "resolved": "http://npm.internal.magnet.me:4873/lodash/-/lodash-4.13.1.tgz"
-        },
-        "user-home": {
-          "version": "2.0.0",
-          "from": "user-home@>=2.0.0 <3.0.0",
-          "resolved": "http://npm.internal.magnet.me:4873/user-home/-/user-home-2.0.0.tgz"
-        }
-      }
-    },
-    "eslint-plugin-async-await": {
-      "version": "0.0.0",
-      "from": "eslint-plugin-async-await@0.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/eslint-plugin-async-await/-/eslint-plugin-async-await-0.0.0.tgz"
-    },
-    "espree": {
-      "version": "3.1.6",
-      "from": "espree@>=3.1.6 <4.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/espree/-/espree-3.1.6.tgz"
-    },
-    "esprima": {
-      "version": "2.7.2",
-      "from": "esprima@>=2.6.0 <3.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/esprima/-/esprima-2.7.2.tgz"
-    },
-    "esrecurse": {
-      "version": "4.1.0",
-      "from": "esrecurse@>=4.1.0 <5.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/esrecurse/-/esrecurse-4.1.0.tgz",
-      "dependencies": {
-        "estraverse": {
-          "version": "4.1.1",
-          "from": "estraverse@>=4.1.0 <4.2.0",
-          "resolved": "http://npm.internal.magnet.me:4873/estraverse/-/estraverse-4.1.1.tgz"
-        }
-      }
-    },
-    "estraverse": {
-      "version": "4.2.0",
-      "from": "estraverse@>=4.2.0 <5.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/estraverse/-/estraverse-4.2.0.tgz"
-    },
-    "esutils": {
-      "version": "2.0.2",
-      "from": "esutils@>=2.0.2 <3.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/esutils/-/esutils-2.0.2.tgz"
-    },
-    "etag": {
-      "version": "1.7.0",
-      "from": "etag@>=1.7.0 <1.8.0",
-      "resolved": "http://npm.internal.magnet.me:4873/etag/-/etag-1.7.0.tgz"
-    },
-    "event-emitter": {
-      "version": "0.3.4",
-      "from": "event-emitter@>=0.3.4 <0.4.0",
-      "resolved": "http://npm.internal.magnet.me:4873/event-emitter/-/event-emitter-0.3.4.tgz"
-    },
-    "exit-hook": {
-      "version": "1.1.1",
-      "from": "exit-hook@>=1.0.0 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/exit-hook/-/exit-hook-1.1.1.tgz"
-    },
-    "expand-brackets": {
-      "version": "0.1.5",
-      "from": "expand-brackets@>=0.1.4 <0.2.0",
-      "resolved": "http://npm.internal.magnet.me:4873/expand-brackets/-/expand-brackets-0.1.5.tgz"
-    },
-    "expand-range": {
-      "version": "1.8.2",
-      "from": "expand-range@>=1.8.1 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/expand-range/-/expand-range-1.8.2.tgz"
     },
     "express": {
       "version": "4.14.0",
-      "from": "express@>=4.13.3 <5.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/express/-/express-4.14.0.tgz"
-    },
-    "extend": {
-      "version": "3.0.0",
-      "from": "extend@>=3.0.0 <3.1.0",
-      "resolved": "http://npm.internal.magnet.me:4873/extend/-/extend-3.0.0.tgz"
-    },
-    "extglob": {
-      "version": "0.3.2",
-      "from": "extglob@>=0.3.1 <0.4.0",
-      "resolved": "http://npm.internal.magnet.me:4873/extglob/-/extglob-0.3.2.tgz"
-    },
-    "extsprintf": {
-      "version": "1.0.2",
-      "from": "extsprintf@1.0.2",
-      "resolved": "http://npm.internal.magnet.me:4873/extsprintf/-/extsprintf-1.0.2.tgz"
-    },
-    "fast-levenshtein": {
-      "version": "1.1.3",
-      "from": "fast-levenshtein@>=1.1.0 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/fast-levenshtein/-/fast-levenshtein-1.1.3.tgz"
-    },
-    "figures": {
-      "version": "1.7.0",
-      "from": "figures@>=1.3.5 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/figures/-/figures-1.7.0.tgz"
-    },
-    "file-entry-cache": {
-      "version": "1.2.4",
-      "from": "file-entry-cache@>=1.1.1 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/file-entry-cache/-/file-entry-cache-1.2.4.tgz"
-    },
-    "filename-regex": {
-      "version": "2.0.0",
-      "from": "filename-regex@>=2.0.0 <3.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/filename-regex/-/filename-regex-2.0.0.tgz"
-    },
-    "fill-range": {
-      "version": "2.2.3",
-      "from": "fill-range@>=2.1.0 <3.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/fill-range/-/fill-range-2.2.3.tgz"
-    },
-    "finalhandler": {
-      "version": "0.5.0",
-      "from": "finalhandler@0.5.0",
-      "resolved": "http://npm.internal.magnet.me:4873/finalhandler/-/finalhandler-0.5.0.tgz"
-    },
-    "find-up": {
-      "version": "1.1.2",
-      "from": "find-up@>=1.0.0 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/find-up/-/find-up-1.1.2.tgz",
+      "from": "express@>=4.14.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.14.0.tgz",
       "dependencies": {
-        "path-exists": {
-          "version": "2.1.0",
-          "from": "path-exists@>=2.0.0 <3.0.0",
-          "resolved": "http://npm.internal.magnet.me:4873/path-exists/-/path-exists-2.1.0.tgz"
+        "accepts": {
+          "version": "1.3.3",
+          "from": "accepts@>=1.3.3 <1.4.0",
+          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
+          "dependencies": {
+            "mime-types": {
+              "version": "2.1.13",
+              "from": "mime-types@>=2.1.11 <2.2.0",
+              "resolved": "http://npm.internal.magnet.me:4873/mime-types/-/mime-types-2.1.13.tgz",
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.25.0",
+                  "from": "mime-db@>=1.25.0 <1.26.0",
+                  "resolved": "http://npm.internal.magnet.me:4873/mime-db/-/mime-db-1.25.0.tgz"
+                }
+              }
+            },
+            "negotiator": {
+              "version": "0.6.1",
+              "from": "negotiator@0.6.1",
+              "resolved": "http://npm.internal.magnet.me:4873/negotiator/-/negotiator-0.6.1.tgz"
+            }
+          }
+        },
+        "array-flatten": {
+          "version": "1.1.1",
+          "from": "array-flatten@1.1.1",
+          "resolved": "http://npm.internal.magnet.me:4873/array-flatten/-/array-flatten-1.1.1.tgz"
+        },
+        "content-disposition": {
+          "version": "0.5.1",
+          "from": "content-disposition@0.5.1",
+          "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz"
+        },
+        "content-type": {
+          "version": "1.0.2",
+          "from": "content-type@>=1.0.2 <1.1.0",
+          "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz"
+        },
+        "cookie": {
+          "version": "0.3.1",
+          "from": "cookie@0.3.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz"
+        },
+        "cookie-signature": {
+          "version": "1.0.6",
+          "from": "cookie-signature@1.0.6",
+          "resolved": "http://npm.internal.magnet.me:4873/cookie-signature/-/cookie-signature-1.0.6.tgz"
+        },
+        "debug": {
+          "version": "2.2.0",
+          "from": "debug@>=2.2.0 <2.3.0",
+          "resolved": "http://npm.internal.magnet.me:4873/debug/-/debug-2.2.0.tgz",
+          "dependencies": {
+            "ms": {
+              "version": "0.7.1",
+              "from": "ms@0.7.1",
+              "resolved": "http://npm.internal.magnet.me:4873/ms/-/ms-0.7.1.tgz"
+            }
+          }
+        },
+        "depd": {
+          "version": "1.1.0",
+          "from": "depd@>=1.1.0 <1.2.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
+        },
+        "encodeurl": {
+          "version": "1.0.1",
+          "from": "encodeurl@>=1.0.1 <1.1.0",
+          "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz"
+        },
+        "escape-html": {
+          "version": "1.0.3",
+          "from": "escape-html@>=1.0.3 <1.1.0",
+          "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
+        },
+        "etag": {
+          "version": "1.7.0",
+          "from": "etag@>=1.7.0 <1.8.0",
+          "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz"
+        },
+        "finalhandler": {
+          "version": "0.5.0",
+          "from": "finalhandler@0.5.0",
+          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz",
+          "dependencies": {
+            "statuses": {
+              "version": "1.3.1",
+              "from": "statuses@>=1.3.0 <1.4.0",
+              "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
+            },
+            "unpipe": {
+              "version": "1.0.0",
+              "from": "unpipe@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
+            }
+          }
+        },
+        "fresh": {
+          "version": "0.3.0",
+          "from": "fresh@0.3.0",
+          "resolved": "http://npm.internal.magnet.me:4873/fresh/-/fresh-0.3.0.tgz"
+        },
+        "merge-descriptors": {
+          "version": "1.0.1",
+          "from": "merge-descriptors@1.0.1",
+          "resolved": "http://npm.internal.magnet.me:4873/merge-descriptors/-/merge-descriptors-1.0.1.tgz"
+        },
+        "methods": {
+          "version": "1.1.2",
+          "from": "methods@>=1.1.2 <1.2.0",
+          "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
+        },
+        "on-finished": {
+          "version": "2.3.0",
+          "from": "on-finished@>=2.3.0 <2.4.0",
+          "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+          "dependencies": {
+            "ee-first": {
+              "version": "1.1.1",
+              "from": "ee-first@1.1.1",
+              "resolved": "http://npm.internal.magnet.me:4873/ee-first/-/ee-first-1.1.1.tgz"
+            }
+          }
+        },
+        "parseurl": {
+          "version": "1.3.1",
+          "from": "parseurl@>=1.3.1 <1.4.0",
+          "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
+        },
+        "path-to-regexp": {
+          "version": "0.1.7",
+          "from": "path-to-regexp@0.1.7",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz"
+        },
+        "proxy-addr": {
+          "version": "1.1.2",
+          "from": "proxy-addr@>=1.1.2 <1.2.0",
+          "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.2.tgz",
+          "dependencies": {
+            "forwarded": {
+              "version": "0.1.0",
+              "from": "forwarded@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz"
+            },
+            "ipaddr.js": {
+              "version": "1.1.1",
+              "from": "ipaddr.js@1.1.1",
+              "resolved": "http://npm.internal.magnet.me:4873/ipaddr.js/-/ipaddr.js-1.1.1.tgz"
+            }
+          }
+        },
+        "qs": {
+          "version": "6.2.0",
+          "from": "qs@6.2.0",
+          "resolved": "http://npm.internal.magnet.me:4873/qs/-/qs-6.2.0.tgz"
+        },
+        "range-parser": {
+          "version": "1.2.0",
+          "from": "range-parser@>=1.2.0 <1.3.0",
+          "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz"
+        },
+        "send": {
+          "version": "0.14.1",
+          "from": "send@0.14.1",
+          "resolved": "https://registry.npmjs.org/send/-/send-0.14.1.tgz",
+          "dependencies": {
+            "destroy": {
+              "version": "1.0.4",
+              "from": "destroy@>=1.0.4 <1.1.0",
+              "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
+            },
+            "http-errors": {
+              "version": "1.5.1",
+              "from": "http-errors@>=1.5.0 <1.6.0",
+              "resolved": "http://npm.internal.magnet.me:4873/http-errors/-/http-errors-1.5.1.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.3",
+                  "from": "inherits@2.0.3",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                },
+                "setprototypeof": {
+                  "version": "1.0.2",
+                  "from": "setprototypeof@1.0.2",
+                  "resolved": "http://npm.internal.magnet.me:4873/setprototypeof/-/setprototypeof-1.0.2.tgz"
+                }
+              }
+            },
+            "mime": {
+              "version": "1.3.4",
+              "from": "mime@1.3.4",
+              "resolved": "http://npm.internal.magnet.me:4873/mime/-/mime-1.3.4.tgz"
+            },
+            "ms": {
+              "version": "0.7.1",
+              "from": "ms@0.7.1",
+              "resolved": "http://npm.internal.magnet.me:4873/ms/-/ms-0.7.1.tgz"
+            },
+            "statuses": {
+              "version": "1.3.1",
+              "from": "statuses@>=1.3.0 <1.4.0",
+              "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
+            }
+          }
+        },
+        "serve-static": {
+          "version": "1.11.1",
+          "from": "serve-static@>=1.11.1 <1.12.0",
+          "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.11.1.tgz"
+        },
+        "type-is": {
+          "version": "1.6.14",
+          "from": "type-is@>=1.6.13 <1.7.0",
+          "resolved": "http://npm.internal.magnet.me:4873/type-is/-/type-is-1.6.14.tgz",
+          "dependencies": {
+            "media-typer": {
+              "version": "0.3.0",
+              "from": "media-typer@0.3.0",
+              "resolved": "http://npm.internal.magnet.me:4873/media-typer/-/media-typer-0.3.0.tgz"
+            },
+            "mime-types": {
+              "version": "2.1.13",
+              "from": "mime-types@>=2.1.11 <2.2.0",
+              "resolved": "http://npm.internal.magnet.me:4873/mime-types/-/mime-types-2.1.13.tgz",
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.25.0",
+                  "from": "mime-db@>=1.25.0 <1.26.0",
+                  "resolved": "http://npm.internal.magnet.me:4873/mime-db/-/mime-db-1.25.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "utils-merge": {
+          "version": "1.0.0",
+          "from": "utils-merge@1.0.0",
+          "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
+        },
+        "vary": {
+          "version": "1.1.0",
+          "from": "vary@>=1.1.0 <1.2.0",
+          "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz"
         }
       }
-    },
-    "find-versions": {
-      "version": "1.2.1",
-      "from": "find-versions@>=1.0.0 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/find-versions/-/find-versions-1.2.1.tgz"
-    },
-    "flat-cache": {
-      "version": "1.0.10",
-      "from": "flat-cache@>=1.0.9 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/flat-cache/-/flat-cache-1.0.10.tgz"
-    },
-    "for-in": {
-      "version": "0.1.5",
-      "from": "for-in@>=0.1.5 <0.2.0",
-      "resolved": "http://npm.internal.magnet.me:4873/for-in/-/for-in-0.1.5.tgz"
-    },
-    "for-own": {
-      "version": "0.1.4",
-      "from": "for-own@>=0.1.3 <0.2.0",
-      "resolved": "http://npm.internal.magnet.me:4873/for-own/-/for-own-0.1.4.tgz"
-    },
-    "forever-agent": {
-      "version": "0.6.1",
-      "from": "forever-agent@>=0.6.1 <0.7.0",
-      "resolved": "http://npm.internal.magnet.me:4873/forever-agent/-/forever-agent-0.6.1.tgz"
-    },
-    "form-data": {
-      "version": "1.0.0-rc4",
-      "from": "form-data@>=1.0.0-rc3 <1.1.0",
-      "resolved": "http://npm.internal.magnet.me:4873/form-data/-/form-data-1.0.0-rc4.tgz"
     },
     "formidable": {
       "version": "1.0.17",
       "from": "formidable@>=1.0.17 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/formidable/-/formidable-1.0.17.tgz"
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz"
     },
-    "forwarded": {
-      "version": "0.1.0",
-      "from": "forwarded@>=0.1.0 <0.2.0",
-      "resolved": "http://npm.internal.magnet.me:4873/forwarded/-/forwarded-0.1.0.tgz"
-    },
-    "fresh": {
-      "version": "0.3.0",
-      "from": "fresh@0.3.0",
-      "resolved": "http://npm.internal.magnet.me:4873/fresh/-/fresh-0.3.0.tgz"
-    },
-    "fs-extra": {
-      "version": "0.26.7",
-      "from": "fs-extra@>=0.26.4 <0.27.0",
-      "resolved": "http://npm.internal.magnet.me:4873/fs-extra/-/fs-extra-0.26.7.tgz"
-    },
-    "fs-readdir-recursive": {
-      "version": "0.1.2",
-      "from": "fs-readdir-recursive@>=0.1.0 <0.2.0",
-      "resolved": "http://npm.internal.magnet.me:4873/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz"
-    },
-    "fs.realpath": {
-      "version": "1.0.0",
-      "from": "fs.realpath@>=1.0.0 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/fs.realpath/-/fs.realpath-1.0.0.tgz"
-    },
-    "fsevents": {
-      "version": "1.0.12",
-      "from": "fsevents@>=1.0.0 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/fsevents/-/fsevents-1.0.12.tgz",
+    "gm": {
+      "version": "1.23.0",
+      "from": "gm@>=1.23.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/gm/-/gm-1.23.0.tgz",
       "dependencies": {
-        "node-pre-gyp": {
-          "version": "0.6.25",
-          "from": "node-pre-gyp@0.6.25",
-          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.25.tgz",
-          "dependencies": {
-            "nopt": {
-              "version": "3.0.6",
-              "from": "nopt@~3.0.1",
-              "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-              "dependencies": {
-                "abbrev": {
-                  "version": "1.0.7",
-                  "from": "abbrev@1",
-                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
-                }
-              }
-            }
-          }
-        },
-        "ansi": {
-          "version": "0.3.1",
-          "from": "ansi@~0.3.1",
-          "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz"
-        },
-        "ansi-regex": {
-          "version": "2.0.0",
-          "from": "ansi-regex@^2.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "from": "ansi-styles@^2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-        },
-        "are-we-there-yet": {
-          "version": "1.1.2",
-          "from": "are-we-there-yet@~1.1.2",
-          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz"
-        },
-        "asn1": {
-          "version": "0.2.3",
-          "from": "asn1@>=0.2.3 <0.3.0",
-          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
-        },
-        "assert-plus": {
-          "version": "0.2.0",
-          "from": "assert-plus@^0.2.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
-        },
-        "async": {
-          "version": "1.5.2",
-          "from": "async@^1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "from": "aws-sign2@~0.6.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
-        },
-        "bl": {
-          "version": "1.0.3",
-          "from": "bl@~1.0.0",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz"
-        },
-        "block-stream": {
-          "version": "0.0.8",
-          "from": "block-stream@*",
-          "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz"
-        },
-        "boom": {
-          "version": "2.10.1",
-          "from": "boom@2.x.x",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
-        },
-        "caseless": {
-          "version": "0.11.0",
-          "from": "caseless@~0.11.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "from": "chalk@^1.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
-        },
-        "commander": {
-          "version": "2.9.0",
-          "from": "commander@^2.9.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
-        },
-        "combined-stream": {
-          "version": "1.0.5",
-          "from": "combined-stream@~1.0.5",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "from": "core-util-is@~1.0.0",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-        },
-        "cryptiles": {
-          "version": "2.0.5",
-          "from": "cryptiles@2.x.x",
-          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
-        },
-        "debug": {
-          "version": "2.2.0",
-          "from": "debug@~2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
-        },
-        "deep-extend": {
-          "version": "0.4.1",
-          "from": "deep-extend@~0.4.0",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz"
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "from": "delayed-stream@~1.0.0",
-          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
-        },
-        "ecc-jsbn": {
-          "version": "0.1.1",
-          "from": "ecc-jsbn@>=0.0.1 <1.0.0",
-          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
-        },
-        "delegates": {
-          "version": "1.0.0",
-          "from": "delegates@^1.0.0",
-          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "from": "escape-string-regexp@^1.0.2",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-        },
-        "extend": {
-          "version": "3.0.0",
-          "from": "extend@~3.0.0",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
-        },
-        "extsprintf": {
-          "version": "1.0.2",
-          "from": "extsprintf@1.0.2",
-          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "from": "forever-agent@~0.6.1",
-          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
-        },
-        "form-data": {
-          "version": "1.0.0-rc4",
-          "from": "form-data@~1.0.0-rc3",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz"
-        },
-        "fstream": {
-          "version": "1.0.8",
-          "from": "fstream@^1.0.2",
-          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz"
-        },
-        "gauge": {
-          "version": "1.2.7",
-          "from": "gauge@~1.2.5",
-          "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz"
-        },
-        "generate-function": {
-          "version": "2.0.0",
-          "from": "generate-function@^2.0.0",
-          "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
-        },
-        "generate-object-property": {
-          "version": "1.2.0",
-          "from": "generate-object-property@^1.1.0",
-          "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
-        },
-        "graceful-fs": {
-          "version": "4.1.3",
-          "from": "graceful-fs@^4.1.2",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
-        },
-        "har-validator": {
-          "version": "2.0.6",
-          "from": "har-validator@~2.0.6",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz"
-        },
-        "graceful-readlink": {
-          "version": "1.0.1",
-          "from": "graceful-readlink@>= 1.0.0",
-          "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
-        },
-        "has-ansi": {
-          "version": "2.0.0",
-          "from": "has-ansi@^2.0.0",
-          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
-        },
-        "has-unicode": {
-          "version": "2.0.0",
-          "from": "has-unicode@^2.0.0",
-          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.0.tgz"
-        },
-        "hawk": {
-          "version": "3.1.3",
-          "from": "hawk@~3.1.0",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
-        },
-        "hoek": {
-          "version": "2.16.3",
-          "from": "hoek@2.x.x",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-        },
-        "inherits": {
-          "version": "2.0.1",
-          "from": "inherits@*",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-        },
-        "http-signature": {
-          "version": "1.1.1",
-          "from": "http-signature@~1.1.0",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz"
-        },
-        "ini": {
-          "version": "1.3.4",
-          "from": "ini@~1.3.0",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
-        },
-        "is-my-json-valid": {
-          "version": "2.13.1",
-          "from": "is-my-json-valid@^2.12.4",
-          "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz"
-        },
-        "is-property": {
-          "version": "1.0.2",
-          "from": "is-property@^1.0.0",
-          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
-        },
-        "is-typedarray": {
-          "version": "1.0.0",
-          "from": "is-typedarray@~1.0.0",
-          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "from": "isarray@~1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "from": "isstream@~0.1.2",
-          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
-        },
-        "jodid25519": {
-          "version": "1.0.2",
-          "from": "jodid25519@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
-        },
-        "jsbn": {
-          "version": "0.1.0",
-          "from": "jsbn@>=0.1.0 <0.2.0",
-          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
-        },
-        "json-schema": {
-          "version": "0.2.2",
-          "from": "json-schema@0.2.2",
-          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "from": "json-stringify-safe@~5.0.1",
-          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
-        },
-        "jsonpointer": {
-          "version": "2.0.0",
-          "from": "jsonpointer@2.0.0",
-          "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
-        },
-        "jsprim": {
-          "version": "1.2.2",
-          "from": "jsprim@^1.2.2",
-          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz"
-        },
-        "lodash.pad": {
-          "version": "4.1.0",
-          "from": "lodash.pad@^4.1.0",
-          "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.1.0.tgz"
-        },
-        "lodash.padend": {
-          "version": "4.2.0",
-          "from": "lodash.padend@^4.1.0",
-          "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.2.0.tgz"
-        },
-        "lodash.padstart": {
-          "version": "4.2.0",
-          "from": "lodash.padstart@^4.1.0",
-          "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.2.0.tgz"
-        },
-        "lodash.repeat": {
-          "version": "4.0.0",
-          "from": "lodash.repeat@^4.0.0",
-          "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-4.0.0.tgz"
-        },
-        "lodash.tostring": {
-          "version": "4.1.2",
-          "from": "lodash.tostring@^4.0.0",
-          "resolved": "https://registry.npmjs.org/lodash.tostring/-/lodash.tostring-4.1.2.tgz"
-        },
-        "mime-db": {
-          "version": "1.22.0",
-          "from": "mime-db@~1.22.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz"
-        },
-        "mime-types": {
-          "version": "2.1.10",
-          "from": "mime-types@~2.1.7",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz"
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "from": "minimist@0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "from": "mkdirp@>=0.3.0 <0.4.0||>=0.4.0 <0.5.0||>=0.5.0 <0.6.0",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
-        },
-        "ms": {
-          "version": "0.7.1",
-          "from": "ms@0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-        },
-        "node-uuid": {
-          "version": "1.4.7",
-          "from": "node-uuid@~1.4.7",
-          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
-        },
-        "npmlog": {
-          "version": "2.0.3",
-          "from": "npmlog@~2.0.0",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.3.tgz"
-        },
-        "oauth-sign": {
-          "version": "0.8.1",
-          "from": "oauth-sign@~0.8.0",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.1.tgz"
-        },
-        "once": {
-          "version": "1.3.3",
-          "from": "once@~1.3.3",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
-        },
-        "pinkie": {
-          "version": "2.0.4",
-          "from": "pinkie@^2.0.0",
-          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
-        },
-        "pinkie-promise": {
-          "version": "2.0.0",
-          "from": "pinkie-promise@^2.0.0",
-          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz"
-        },
-        "process-nextick-args": {
-          "version": "1.0.6",
-          "from": "process-nextick-args@~1.0.6",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
-        },
-        "qs": {
-          "version": "6.0.2",
-          "from": "qs@~6.0.2",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.0.2.tgz"
-        },
-        "readable-stream": {
-          "version": "2.0.6",
-          "from": "readable-stream@^2.0.0 || ^1.1.13",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
-        },
-        "request": {
-          "version": "2.69.0",
-          "from": "request@2.x",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.69.0.tgz"
-        },
-        "semver": {
-          "version": "5.1.0",
-          "from": "semver@~5.1.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
-        },
-        "sntp": {
-          "version": "1.0.9",
-          "from": "sntp@1.x.x",
-          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
-        },
-        "sshpk": {
-          "version": "1.7.4",
-          "from": "sshpk@^1.7.0",
-          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.4.tgz"
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "from": "string_decoder@~0.10.x",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-        },
-        "stringstream": {
-          "version": "0.0.5",
-          "from": "stringstream@~0.0.4",
-          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
-        },
-        "strip-json-comments": {
-          "version": "1.0.4",
-          "from": "strip-json-comments@~1.0.4",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "from": "strip-ansi@^3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "from": "supports-color@^2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-        },
-        "tar": {
-          "version": "2.2.1",
-          "from": "tar@~2.2.0",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz"
-        },
-        "tar-pack": {
-          "version": "3.1.3",
-          "from": "tar-pack@~3.1.0",
-          "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.1.3.tgz"
-        },
-        "tough-cookie": {
-          "version": "2.2.2",
-          "from": "tough-cookie@~2.2.0",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz"
-        },
-        "tunnel-agent": {
-          "version": "0.4.2",
-          "from": "tunnel-agent@~0.4.1",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
-        },
-        "tweetnacl": {
-          "version": "0.14.3",
-          "from": "tweetnacl@>=0.13.0 <1.0.0",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz"
-        },
-        "uid-number": {
-          "version": "0.0.6",
-          "from": "uid-number@~0.0.6",
-          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz"
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "from": "util-deprecate@~1.0.1",
-          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-        },
-        "verror": {
-          "version": "1.3.6",
-          "from": "verror@1.3.6",
-          "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
-        },
-        "wrappy": {
-          "version": "1.0.1",
-          "from": "wrappy@1",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-        },
-        "xtend": {
-          "version": "4.0.1",
-          "from": "xtend@^4.0.0",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-        },
-        "dashdash": {
-          "version": "1.13.0",
-          "from": "dashdash@>=1.10.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.13.0.tgz",
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "from": "assert-plus@^1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
-            }
-          }
-        },
-        "rc": {
-          "version": "1.1.6",
-          "from": "rc@~1.1.0",
-          "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "from": "minimist@^1.2.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
-            }
-          }
-        },
-        "aws4": {
-          "version": "1.3.2",
-          "from": "aws4@^1.2.1",
-          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.3.2.tgz",
+        "array-parallel": {
+          "version": "0.1.3",
+          "from": "array-parallel@>=0.1.3 <0.2.0",
+          "resolved": "https://registry.npmjs.org/array-parallel/-/array-parallel-0.1.3.tgz"
+        },
+        "array-series": {
+          "version": "0.1.5",
+          "from": "array-series@>=0.1.5 <0.2.0",
+          "resolved": "https://registry.npmjs.org/array-series/-/array-series-0.1.5.tgz"
+        },
+        "cross-spawn": {
+          "version": "4.0.2",
+          "from": "cross-spawn@>=4.0.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
           "dependencies": {
             "lru-cache": {
-              "version": "4.0.1",
-              "from": "lru-cache@^4.0.0",
-              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.1.tgz",
+              "version": "4.0.2",
+              "from": "lru-cache@>=4.0.1 <5.0.0",
+              "resolved": "http://npm.internal.magnet.me:4873/lru-cache/-/lru-cache-4.0.2.tgz",
               "dependencies": {
                 "pseudomap": {
                   "version": "1.0.2",
-                  "from": "pseudomap@^1.0.1",
-                  "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz"
+                  "from": "pseudomap@>=1.0.1 <2.0.0",
+                  "resolved": "http://npm.internal.magnet.me:4873/pseudomap/-/pseudomap-1.0.2.tgz"
                 },
                 "yallist": {
                   "version": "2.0.0",
-                  "from": "yallist@^2.0.0",
-                  "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz"
+                  "from": "yallist@>=2.0.0 <3.0.0",
+                  "resolved": "http://npm.internal.magnet.me:4873/yallist/-/yallist-2.0.0.tgz"
+                }
+              }
+            },
+            "which": {
+              "version": "1.2.12",
+              "from": "which@>=1.2.9 <2.0.0",
+              "resolved": "https://registry.npmjs.org/which/-/which-1.2.12.tgz",
+              "dependencies": {
+                "isexe": {
+                  "version": "1.1.2",
+                  "from": "isexe@>=1.1.1 <2.0.0",
+                  "resolved": "http://npm.internal.magnet.me:4873/isexe/-/isexe-1.1.2.tgz"
                 }
               }
             }
           }
         },
-        "fstream-ignore": {
-          "version": "1.0.3",
-          "from": "fstream-ignore@~1.0.3",
-          "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.3.tgz",
+        "debug": {
+          "version": "2.2.0",
+          "from": "debug@>=2.2.0 <2.3.0",
+          "resolved": "http://npm.internal.magnet.me:4873/debug/-/debug-2.2.0.tgz",
           "dependencies": {
-            "minimatch": {
-              "version": "3.0.0",
-              "from": "minimatch@^3.0.0",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.3",
-                  "from": "brace-expansion@^1.0.0",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "0.3.0",
-                      "from": "balanced-match@^0.3.0",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "from": "concat-map@0.0.1",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "rimraf": {
-          "version": "2.5.2",
-          "from": "rimraf@~2.5.0",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
-          "dependencies": {
-            "glob": {
-              "version": "7.0.3",
-              "from": "glob@^7.0.0",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
-              "dependencies": {
-                "inflight": {
-                  "version": "1.0.4",
-                  "from": "inflight@^1.0.4",
-                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "from": "wrappy@1",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@2",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "minimatch": {
-                  "version": "3.0.0",
-                  "from": "minimatch@2 || 3",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.3",
-                      "from": "brace-expansion@^1.0.0",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "0.3.0",
-                          "from": "balanced-match@^0.3.0",
-                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "from": "concat-map@0.0.1",
-                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "once": {
-                  "version": "1.3.3",
-                  "from": "once@^1.3.0",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "from": "wrappy@1",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                },
-                "path-is-absolute": {
-                  "version": "1.0.0",
-                  "from": "path-is-absolute@^1.0.0",
-                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
-                }
-              }
+            "ms": {
+              "version": "0.7.1",
+              "from": "ms@0.7.1",
+              "resolved": "http://npm.internal.magnet.me:4873/ms/-/ms-0.7.1.tgz"
             }
           }
         }
       }
-    },
-    "generate-function": {
-      "version": "2.0.0",
-      "from": "generate-function@>=2.0.0 <3.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/generate-function/-/generate-function-2.0.0.tgz"
-    },
-    "generate-object-property": {
-      "version": "1.2.0",
-      "from": "generate-object-property@>=1.1.0 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/generate-object-property/-/generate-object-property-1.2.0.tgz"
-    },
-    "generic-pool": {
-      "version": "2.4.2",
-      "from": "generic-pool@2.4.2",
-      "resolved": "http://npm.internal.magnet.me:4873/generic-pool/-/generic-pool-2.4.2.tgz"
-    },
-    "get-stdin": {
-      "version": "4.0.1",
-      "from": "get-stdin@>=4.0.1 <5.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/get-stdin/-/get-stdin-4.0.1.tgz"
-    },
-    "getpass": {
-      "version": "0.1.6",
-      "from": "getpass@>=0.1.1 <0.2.0",
-      "resolved": "http://npm.internal.magnet.me:4873/getpass/-/getpass-0.1.6.tgz",
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "from": "assert-plus@>=1.0.0 <2.0.0",
-          "resolved": "http://npm.internal.magnet.me:4873/assert-plus/-/assert-plus-1.0.0.tgz"
-        }
-      }
-    },
-    "glob": {
-      "version": "7.0.5",
-      "from": "glob@>=7.0.0 <8.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/glob/-/glob-7.0.5.tgz"
-    },
-    "glob-base": {
-      "version": "0.3.0",
-      "from": "glob-base@>=0.3.0 <0.4.0",
-      "resolved": "http://npm.internal.magnet.me:4873/glob-base/-/glob-base-0.3.0.tgz"
-    },
-    "glob-parent": {
-      "version": "2.0.0",
-      "from": "glob-parent@>=2.0.0 <3.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/glob-parent/-/glob-parent-2.0.0.tgz"
-    },
-    "globals": {
-      "version": "8.18.0",
-      "from": "globals@>=8.3.0 <9.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/globals/-/globals-8.18.0.tgz"
-    },
-    "globby": {
-      "version": "5.0.0",
-      "from": "globby@>=5.0.0 <6.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/globby/-/globby-5.0.0.tgz"
-    },
-    "gm": {
-      "version": "1.22.0",
-      "from": "gm@>=1.22.0 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/gm/-/gm-1.22.0.tgz"
-    },
-    "graceful-fs": {
-      "version": "4.1.4",
-      "from": "graceful-fs@>=4.1.2 <5.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/graceful-fs/-/graceful-fs-4.1.4.tgz"
-    },
-    "graceful-readlink": {
-      "version": "1.0.1",
-      "from": "graceful-readlink@>=1.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
-    },
-    "har-validator": {
-      "version": "2.0.6",
-      "from": "har-validator@>=2.0.6 <2.1.0",
-      "resolved": "http://npm.internal.magnet.me:4873/har-validator/-/har-validator-2.0.6.tgz"
-    },
-    "has-ansi": {
-      "version": "2.0.0",
-      "from": "has-ansi@>=2.0.0 <3.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/has-ansi/-/has-ansi-2.0.0.tgz"
-    },
-    "hawk": {
-      "version": "3.1.3",
-      "from": "hawk@>=3.1.3 <3.2.0",
-      "resolved": "http://npm.internal.magnet.me:4873/hawk/-/hawk-3.1.3.tgz"
-    },
-    "hoek": {
-      "version": "2.16.3",
-      "from": "hoek@>=2.0.0 <3.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/hoek/-/hoek-2.16.3.tgz"
-    },
-    "home-or-tmp": {
-      "version": "1.0.0",
-      "from": "home-or-tmp@>=1.0.0 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/home-or-tmp/-/home-or-tmp-1.0.0.tgz"
-    },
-    "hosted-git-info": {
-      "version": "2.1.5",
-      "from": "hosted-git-info@>=2.1.4 <3.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/hosted-git-info/-/hosted-git-info-2.1.5.tgz"
-    },
-    "http-errors": {
-      "version": "1.5.0",
-      "from": "http-errors@>=1.5.0 <1.6.0",
-      "resolved": "http://npm.internal.magnet.me:4873/http-errors/-/http-errors-1.5.0.tgz"
-    },
-    "http-signature": {
-      "version": "1.1.1",
-      "from": "http-signature@>=1.1.0 <1.2.0",
-      "resolved": "http://npm.internal.magnet.me:4873/http-signature/-/http-signature-1.1.1.tgz"
-    },
-    "iconv-lite": {
-      "version": "0.4.13",
-      "from": "iconv-lite@0.4.13",
-      "resolved": "http://npm.internal.magnet.me:4873/iconv-lite/-/iconv-lite-0.4.13.tgz"
-    },
-    "ignore": {
-      "version": "3.1.3",
-      "from": "ignore@>=3.1.2 <4.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/ignore/-/ignore-3.1.3.tgz"
-    },
-    "imurmurhash": {
-      "version": "0.1.4",
-      "from": "imurmurhash@>=0.1.4 <0.2.0",
-      "resolved": "http://npm.internal.magnet.me:4873/imurmurhash/-/imurmurhash-0.1.4.tgz"
-    },
-    "indent-string": {
-      "version": "2.1.0",
-      "from": "indent-string@>=2.1.0 <3.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/indent-string/-/indent-string-2.1.0.tgz",
-      "dependencies": {
-        "repeating": {
-          "version": "2.0.1",
-          "from": "repeating@>=2.0.0 <3.0.0",
-          "resolved": "http://npm.internal.magnet.me:4873/repeating/-/repeating-2.0.1.tgz"
-        }
-      }
-    },
-    "inflight": {
-      "version": "1.0.5",
-      "from": "inflight@>=1.0.4 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/inflight/-/inflight-1.0.5.tgz"
-    },
-    "inherits": {
-      "version": "2.0.1",
-      "from": "inherits@2.0.1",
-      "resolved": "http://npm.internal.magnet.me:4873/inherits/-/inherits-2.0.1.tgz"
-    },
-    "inquirer": {
-      "version": "0.12.0",
-      "from": "inquirer@>=0.12.0 <0.13.0",
-      "resolved": "http://npm.internal.magnet.me:4873/inquirer/-/inquirer-0.12.0.tgz",
-      "dependencies": {
-        "lodash": {
-          "version": "4.13.1",
-          "from": "lodash@>=4.3.0 <5.0.0",
-          "resolved": "http://npm.internal.magnet.me:4873/lodash/-/lodash-4.13.1.tgz"
-        }
-      }
-    },
-    "invariant": {
-      "version": "2.2.1",
-      "from": "invariant@>=2.2.0 <3.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/invariant/-/invariant-2.2.1.tgz"
-    },
-    "ipaddr.js": {
-      "version": "1.1.1",
-      "from": "ipaddr.js@1.1.1",
-      "resolved": "http://npm.internal.magnet.me:4873/ipaddr.js/-/ipaddr.js-1.1.1.tgz"
-    },
-    "is-arrayish": {
-      "version": "0.2.1",
-      "from": "is-arrayish@>=0.2.1 <0.3.0",
-      "resolved": "http://npm.internal.magnet.me:4873/is-arrayish/-/is-arrayish-0.2.1.tgz"
-    },
-    "is-binary-path": {
-      "version": "1.0.1",
-      "from": "is-binary-path@>=1.0.0 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/is-binary-path/-/is-binary-path-1.0.1.tgz"
-    },
-    "is-buffer": {
-      "version": "1.1.3",
-      "from": "is-buffer@>=1.0.2 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/is-buffer/-/is-buffer-1.1.3.tgz"
-    },
-    "is-builtin-module": {
-      "version": "1.0.0",
-      "from": "is-builtin-module@>=1.0.0 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/is-builtin-module/-/is-builtin-module-1.0.0.tgz"
-    },
-    "is-dotfile": {
-      "version": "1.0.2",
-      "from": "is-dotfile@>=1.0.0 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/is-dotfile/-/is-dotfile-1.0.2.tgz"
-    },
-    "is-equal-shallow": {
-      "version": "0.1.3",
-      "from": "is-equal-shallow@>=0.1.3 <0.2.0",
-      "resolved": "http://npm.internal.magnet.me:4873/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
-    },
-    "is-extendable": {
-      "version": "0.1.1",
-      "from": "is-extendable@>=0.1.1 <0.2.0",
-      "resolved": "http://npm.internal.magnet.me:4873/is-extendable/-/is-extendable-0.1.1.tgz"
-    },
-    "is-extglob": {
-      "version": "1.0.0",
-      "from": "is-extglob@>=1.0.0 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/is-extglob/-/is-extglob-1.0.0.tgz"
-    },
-    "is-finite": {
-      "version": "1.0.1",
-      "from": "is-finite@>=1.0.0 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/is-finite/-/is-finite-1.0.1.tgz"
-    },
-    "is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz"
-    },
-    "is-glob": {
-      "version": "2.0.1",
-      "from": "is-glob@>=2.0.0 <3.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/is-glob/-/is-glob-2.0.1.tgz"
-    },
-    "is-my-json-valid": {
-      "version": "2.13.1",
-      "from": "is-my-json-valid@>=2.12.4 <3.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz"
-    },
-    "is-number": {
-      "version": "2.1.0",
-      "from": "is-number@>=2.1.0 <3.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/is-number/-/is-number-2.1.0.tgz"
-    },
-    "is-path-cwd": {
-      "version": "1.0.0",
-      "from": "is-path-cwd@>=1.0.0 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/is-path-cwd/-/is-path-cwd-1.0.0.tgz"
-    },
-    "is-path-in-cwd": {
-      "version": "1.0.0",
-      "from": "is-path-in-cwd@>=1.0.0 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz"
-    },
-    "is-path-inside": {
-      "version": "1.0.0",
-      "from": "is-path-inside@>=1.0.0 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/is-path-inside/-/is-path-inside-1.0.0.tgz"
-    },
-    "is-posix-bracket": {
-      "version": "0.1.1",
-      "from": "is-posix-bracket@>=0.1.0 <0.2.0",
-      "resolved": "http://npm.internal.magnet.me:4873/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz"
-    },
-    "is-primitive": {
-      "version": "2.0.0",
-      "from": "is-primitive@>=2.0.0 <3.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/is-primitive/-/is-primitive-2.0.0.tgz"
-    },
-    "is-property": {
-      "version": "1.0.2",
-      "from": "is-property@>=1.0.0 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/is-property/-/is-property-1.0.2.tgz"
-    },
-    "is-resolvable": {
-      "version": "1.0.0",
-      "from": "is-resolvable@>=1.0.0 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/is-resolvable/-/is-resolvable-1.0.0.tgz"
-    },
-    "is-typedarray": {
-      "version": "1.0.0",
-      "from": "is-typedarray@>=1.0.0 <1.1.0",
-      "resolved": "http://npm.internal.magnet.me:4873/is-typedarray/-/is-typedarray-1.0.0.tgz"
-    },
-    "is-utf8": {
-      "version": "0.2.1",
-      "from": "is-utf8@>=0.2.0 <0.3.0",
-      "resolved": "http://npm.internal.magnet.me:4873/is-utf8/-/is-utf8-0.2.1.tgz"
-    },
-    "isarray": {
-      "version": "1.0.0",
-      "from": "isarray@1.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/isarray/-/isarray-1.0.0.tgz"
-    },
-    "isobject": {
-      "version": "2.1.0",
-      "from": "isobject@>=2.0.0 <3.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/isobject/-/isobject-2.1.0.tgz"
-    },
-    "isstream": {
-      "version": "0.1.2",
-      "from": "isstream@>=0.1.2 <0.2.0",
-      "resolved": "http://npm.internal.magnet.me:4873/isstream/-/isstream-0.1.2.tgz"
-    },
-    "jmespath": {
-      "version": "0.15.0",
-      "from": "jmespath@0.15.0",
-      "resolved": "http://npm.internal.magnet.me:4873/jmespath/-/jmespath-0.15.0.tgz"
-    },
-    "jodid25519": {
-      "version": "1.0.2",
-      "from": "jodid25519@>=1.0.0 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/jodid25519/-/jodid25519-1.0.2.tgz"
-    },
-    "js-tokens": {
-      "version": "2.0.0",
-      "from": "js-tokens@>=2.0.0 <3.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/js-tokens/-/js-tokens-2.0.0.tgz"
-    },
-    "js-yaml": {
-      "version": "3.6.1",
-      "from": "js-yaml@>=3.5.1 <4.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/js-yaml/-/js-yaml-3.6.1.tgz"
-    },
-    "jsbn": {
-      "version": "0.1.0",
-      "from": "jsbn@>=0.1.0 <0.2.0",
-      "resolved": "http://npm.internal.magnet.me:4873/jsbn/-/jsbn-0.1.0.tgz"
-    },
-    "jsesc": {
-      "version": "0.5.0",
-      "from": "jsesc@>=0.5.0 <0.6.0",
-      "resolved": "http://npm.internal.magnet.me:4873/jsesc/-/jsesc-0.5.0.tgz"
-    },
-    "json-schema": {
-      "version": "0.2.2",
-      "from": "json-schema@0.2.2",
-      "resolved": "http://npm.internal.magnet.me:4873/json-schema/-/json-schema-0.2.2.tgz"
-    },
-    "json-stable-stringify": {
-      "version": "1.0.1",
-      "from": "json-stable-stringify@>=1.0.0 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz"
-    },
-    "json-stringify-safe": {
-      "version": "5.0.1",
-      "from": "json-stringify-safe@>=5.0.1 <5.1.0",
-      "resolved": "http://npm.internal.magnet.me:4873/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
-    },
-    "json5": {
-      "version": "0.4.0",
-      "from": "json5@0.4.0",
-      "resolved": "http://npm.internal.magnet.me:4873/json5/-/json5-0.4.0.tgz"
-    },
-    "jsonfile": {
-      "version": "2.3.1",
-      "from": "jsonfile@>=2.1.0 <3.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/jsonfile/-/jsonfile-2.3.1.tgz"
-    },
-    "jsonify": {
-      "version": "0.0.0",
-      "from": "jsonify@>=0.0.0 <0.1.0",
-      "resolved": "http://npm.internal.magnet.me:4873/jsonify/-/jsonify-0.0.0.tgz"
-    },
-    "jsonpointer": {
-      "version": "2.0.0",
-      "from": "jsonpointer@2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/jsonpointer/-/jsonpointer-2.0.0.tgz"
-    },
-    "jsprim": {
-      "version": "1.3.0",
-      "from": "jsprim@>=1.2.2 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/jsprim/-/jsprim-1.3.0.tgz"
-    },
-    "kind-of": {
-      "version": "3.0.3",
-      "from": "kind-of@>=3.0.2 <4.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/kind-of/-/kind-of-3.0.3.tgz"
-    },
-    "klaw": {
-      "version": "1.3.0",
-      "from": "klaw@>=1.0.0 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/klaw/-/klaw-1.3.0.tgz"
-    },
-    "levn": {
-      "version": "0.3.0",
-      "from": "levn@>=0.3.0 <0.4.0",
-      "resolved": "http://npm.internal.magnet.me:4873/levn/-/levn-0.3.0.tgz"
-    },
-    "load-json-file": {
-      "version": "1.1.0",
-      "from": "load-json-file@>=1.0.0 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/load-json-file/-/load-json-file-1.1.0.tgz"
-    },
-    "lodash": {
-      "version": "3.5.0",
-      "from": "lodash@>=3.5.0 <3.6.0",
-      "resolved": "http://npm.internal.magnet.me:4873/lodash/-/lodash-3.5.0.tgz"
-    },
-    "lodash._baseiteratee": {
-      "version": "4.7.0",
-      "from": "lodash._baseiteratee@>=4.7.0 <4.8.0",
-      "resolved": "http://npm.internal.magnet.me:4873/lodash._baseiteratee/-/lodash._baseiteratee-4.7.0.tgz"
-    },
-    "lodash._basetostring": {
-      "version": "4.12.0",
-      "from": "lodash._basetostring@>=4.12.0 <4.13.0",
-      "resolved": "http://npm.internal.magnet.me:4873/lodash._basetostring/-/lodash._basetostring-4.12.0.tgz"
-    },
-    "lodash._stringtopath": {
-      "version": "4.8.0",
-      "from": "lodash._stringtopath@>=4.8.0 <4.9.0",
-      "resolved": "http://npm.internal.magnet.me:4873/lodash._stringtopath/-/lodash._stringtopath-4.8.0.tgz"
-    },
-    "lodash.assign": {
-      "version": "4.0.9",
-      "from": "lodash.assign@>=4.0.0 <5.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/lodash.assign/-/lodash.assign-4.0.9.tgz"
-    },
-    "lodash.keys": {
-      "version": "4.0.7",
-      "from": "lodash.keys@>=4.0.0 <5.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/lodash.keys/-/lodash.keys-4.0.7.tgz"
-    },
-    "lodash.keysin": {
-      "version": "4.1.4",
-      "from": "lodash.keysin@>=4.0.0 <5.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/lodash.keysin/-/lodash.keysin-4.1.4.tgz"
-    },
-    "lodash.pickby": {
-      "version": "4.4.0",
-      "from": "lodash.pickby@>=4.0.0 <5.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/lodash.pickby/-/lodash.pickby-4.4.0.tgz"
-    },
-    "lodash.rest": {
-      "version": "4.0.3",
-      "from": "lodash.rest@>=4.0.0 <5.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/lodash.rest/-/lodash.rest-4.0.3.tgz"
-    },
-    "log-symbols": {
-      "version": "1.0.2",
-      "from": "log-symbols@>=1.0.2 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/log-symbols/-/log-symbols-1.0.2.tgz"
-    },
-    "loose-envify": {
-      "version": "1.2.0",
-      "from": "loose-envify@>=1.0.0 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/loose-envify/-/loose-envify-1.2.0.tgz",
-      "dependencies": {
-        "js-tokens": {
-          "version": "1.0.3",
-          "from": "js-tokens@>=1.0.1 <2.0.0",
-          "resolved": "http://npm.internal.magnet.me:4873/js-tokens/-/js-tokens-1.0.3.tgz"
-        }
-      }
-    },
-    "loud-rejection": {
-      "version": "1.5.0",
-      "from": "loud-rejection@>=1.0.0 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/loud-rejection/-/loud-rejection-1.5.0.tgz"
-    },
-    "map-obj": {
-      "version": "1.0.1",
-      "from": "map-obj@>=1.0.1 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/map-obj/-/map-obj-1.0.1.tgz"
-    },
-    "media-typer": {
-      "version": "0.3.0",
-      "from": "media-typer@0.3.0",
-      "resolved": "http://npm.internal.magnet.me:4873/media-typer/-/media-typer-0.3.0.tgz"
-    },
-    "meow": {
-      "version": "3.7.0",
-      "from": "meow@>=3.5.0 <4.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/meow/-/meow-3.7.0.tgz"
-    },
-    "merge-descriptors": {
-      "version": "1.0.1",
-      "from": "merge-descriptors@1.0.1",
-      "resolved": "http://npm.internal.magnet.me:4873/merge-descriptors/-/merge-descriptors-1.0.1.tgz"
-    },
-    "methods": {
-      "version": "1.1.2",
-      "from": "methods@>=1.1.2 <1.2.0",
-      "resolved": "http://npm.internal.magnet.me:4873/methods/-/methods-1.1.2.tgz"
-    },
-    "micromatch": {
-      "version": "2.3.10",
-      "from": "micromatch@>=2.1.5 <3.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/micromatch/-/micromatch-2.3.10.tgz"
-    },
-    "mime": {
-      "version": "1.3.4",
-      "from": "mime@1.3.4",
-      "resolved": "http://npm.internal.magnet.me:4873/mime/-/mime-1.3.4.tgz"
-    },
-    "mime-db": {
-      "version": "1.23.0",
-      "from": "mime-db@>=1.23.0 <1.24.0",
-      "resolved": "http://npm.internal.magnet.me:4873/mime-db/-/mime-db-1.23.0.tgz"
-    },
-    "mime-types": {
-      "version": "2.1.11",
-      "from": "mime-types@>=2.1.11 <2.2.0",
-      "resolved": "http://npm.internal.magnet.me:4873/mime-types/-/mime-types-2.1.11.tgz"
-    },
-    "minimatch": {
-      "version": "3.0.2",
-      "from": "minimatch@>=3.0.2 <4.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/minimatch/-/minimatch-3.0.2.tgz"
-    },
-    "minimist": {
-      "version": "1.2.0",
-      "from": "minimist@>=1.1.0 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/minimist/-/minimist-1.2.0.tgz"
-    },
-    "mkdirp": {
-      "version": "0.5.1",
-      "from": "mkdirp@>=0.5.1 <0.6.0",
-      "resolved": "http://npm.internal.magnet.me:4873/mkdirp/-/mkdirp-0.5.1.tgz",
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.8",
-          "from": "minimist@0.0.8",
-          "resolved": "http://npm.internal.magnet.me:4873/minimist/-/minimist-0.0.8.tgz"
-        }
-      }
-    },
-    "ms": {
-      "version": "0.7.1",
-      "from": "ms@0.7.1",
-      "resolved": "http://npm.internal.magnet.me:4873/ms/-/ms-0.7.1.tgz"
-    },
-    "mute-stream": {
-      "version": "0.0.5",
-      "from": "mute-stream@0.0.5",
-      "resolved": "http://npm.internal.magnet.me:4873/mute-stream/-/mute-stream-0.0.5.tgz"
-    },
-    "nan": {
-      "version": "2.3.5",
-      "from": "nan@>=2.3.0 <3.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/nan/-/nan-2.3.5.tgz"
-    },
-    "negotiator": {
-      "version": "0.6.1",
-      "from": "negotiator@0.6.1",
-      "resolved": "http://npm.internal.magnet.me:4873/negotiator/-/negotiator-0.6.1.tgz"
-    },
-    "node-uuid": {
-      "version": "1.4.7",
-      "from": "node-uuid@>=1.4.7 <1.5.0",
-      "resolved": "http://npm.internal.magnet.me:4873/node-uuid/-/node-uuid-1.4.7.tgz"
-    },
-    "nodegit-promise": {
-      "version": "4.0.0",
-      "from": "nodegit-promise@>=4.0.0 <4.1.0",
-      "resolved": "http://npm.internal.magnet.me:4873/nodegit-promise/-/nodegit-promise-4.0.0.tgz"
-    },
-    "normalize-package-data": {
-      "version": "2.3.5",
-      "from": "normalize-package-data@>=2.3.4 <3.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/normalize-package-data/-/normalize-package-data-2.3.5.tgz"
-    },
-    "normalize-path": {
-      "version": "2.0.1",
-      "from": "normalize-path@>=2.0.1 <3.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/normalize-path/-/normalize-path-2.0.1.tgz"
-    },
-    "number-is-nan": {
-      "version": "1.0.0",
-      "from": "number-is-nan@>=1.0.0 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/number-is-nan/-/number-is-nan-1.0.0.tgz"
-    },
-    "oauth-sign": {
-      "version": "0.8.2",
-      "from": "oauth-sign@>=0.8.1 <0.9.0",
-      "resolved": "http://npm.internal.magnet.me:4873/oauth-sign/-/oauth-sign-0.8.2.tgz"
-    },
-    "object-assign": {
-      "version": "4.1.0",
-      "from": "object-assign@>=4.0.1 <5.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/object-assign/-/object-assign-4.1.0.tgz"
-    },
-    "object.omit": {
-      "version": "2.0.0",
-      "from": "object.omit@>=2.0.0 <3.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/object.omit/-/object.omit-2.0.0.tgz"
-    },
-    "on-finished": {
-      "version": "2.3.0",
-      "from": "on-finished@>=2.3.0 <2.4.0",
-      "resolved": "http://npm.internal.magnet.me:4873/on-finished/-/on-finished-2.3.0.tgz"
-    },
-    "once": {
-      "version": "1.3.3",
-      "from": "once@>=1.3.0 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/once/-/once-1.3.3.tgz"
-    },
-    "onetime": {
-      "version": "1.1.0",
-      "from": "onetime@>=1.0.0 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/onetime/-/onetime-1.1.0.tgz"
-    },
-    "optionator": {
-      "version": "0.8.1",
-      "from": "optionator@>=0.8.1 <0.9.0",
-      "resolved": "http://npm.internal.magnet.me:4873/optionator/-/optionator-0.8.1.tgz"
-    },
-    "os-homedir": {
-      "version": "1.0.1",
-      "from": "os-homedir@>=1.0.0 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/os-homedir/-/os-homedir-1.0.1.tgz"
-    },
-    "os-tmpdir": {
-      "version": "1.0.1",
-      "from": "os-tmpdir@>=1.0.1 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
-    },
-    "output-file-sync": {
-      "version": "1.1.2",
-      "from": "output-file-sync@>=1.1.0 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/output-file-sync/-/output-file-sync-1.1.2.tgz"
-    },
-    "packet-reader": {
-      "version": "0.2.0",
-      "from": "packet-reader@0.2.0",
-      "resolved": "http://npm.internal.magnet.me:4873/packet-reader/-/packet-reader-0.2.0.tgz"
-    },
-    "parse-glob": {
-      "version": "3.0.4",
-      "from": "parse-glob@>=3.0.4 <4.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/parse-glob/-/parse-glob-3.0.4.tgz"
-    },
-    "parse-json": {
-      "version": "2.2.0",
-      "from": "parse-json@>=2.2.0 <3.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/parse-json/-/parse-json-2.2.0.tgz"
-    },
-    "parseurl": {
-      "version": "1.3.1",
-      "from": "parseurl@>=1.3.1 <1.4.0",
-      "resolved": "http://npm.internal.magnet.me:4873/parseurl/-/parseurl-1.3.1.tgz"
-    },
-    "path-exists": {
-      "version": "1.0.0",
-      "from": "path-exists@>=1.0.0 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/path-exists/-/path-exists-1.0.0.tgz"
-    },
-    "path-is-absolute": {
-      "version": "1.0.0",
-      "from": "path-is-absolute@>=1.0.0 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
-    },
-    "path-is-inside": {
-      "version": "1.0.1",
-      "from": "path-is-inside@>=1.0.1 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/path-is-inside/-/path-is-inside-1.0.1.tgz"
-    },
-    "path-to-regexp": {
-      "version": "0.1.7",
-      "from": "path-to-regexp@0.1.7",
-      "resolved": "http://npm.internal.magnet.me:4873/path-to-regexp/-/path-to-regexp-0.1.7.tgz"
-    },
-    "path-type": {
-      "version": "1.1.0",
-      "from": "path-type@>=1.0.0 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/path-type/-/path-type-1.1.0.tgz"
     },
     "pg": {
       "version": "4.5.6",
       "from": "pg@>=4.4.3 <5.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/pg/-/pg-4.5.6.tgz"
-    },
-    "pg-connection-string": {
-      "version": "0.1.3",
-      "from": "pg-connection-string@0.1.3",
-      "resolved": "http://npm.internal.magnet.me:4873/pg-connection-string/-/pg-connection-string-0.1.3.tgz"
+      "resolved": "https://registry.npmjs.org/pg/-/pg-4.5.6.tgz",
+      "dependencies": {
+        "buffer-writer": {
+          "version": "1.0.1",
+          "from": "buffer-writer@1.0.1",
+          "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-1.0.1.tgz"
+        },
+        "generic-pool": {
+          "version": "2.4.2",
+          "from": "generic-pool@2.4.2",
+          "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.4.2.tgz"
+        },
+        "packet-reader": {
+          "version": "0.2.0",
+          "from": "packet-reader@0.2.0",
+          "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-0.2.0.tgz"
+        },
+        "pg-connection-string": {
+          "version": "0.1.3",
+          "from": "pg-connection-string@0.1.3",
+          "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-0.1.3.tgz"
+        },
+        "pg-types": {
+          "version": "1.11.0",
+          "from": "pg-types@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-1.11.0.tgz",
+          "dependencies": {
+            "ap": {
+              "version": "0.2.0",
+              "from": "ap@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/ap/-/ap-0.2.0.tgz"
+            },
+            "postgres-array": {
+              "version": "1.0.2",
+              "from": "postgres-array@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-1.0.2.tgz"
+            },
+            "postgres-bytea": {
+              "version": "1.0.0",
+              "from": "postgres-bytea@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz"
+            },
+            "postgres-date": {
+              "version": "1.0.3",
+              "from": "postgres-date@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.3.tgz"
+            },
+            "postgres-interval": {
+              "version": "1.0.2",
+              "from": "postgres-interval@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.0.2.tgz",
+              "dependencies": {
+                "xtend": {
+                  "version": "4.0.1",
+                  "from": "xtend@>=4.0.0 <5.0.0",
+                  "resolved": "http://npm.internal.magnet.me:4873/xtend/-/xtend-4.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "pgpass": {
+          "version": "0.0.3",
+          "from": "pgpass@0.0.3",
+          "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-0.0.3.tgz",
+          "dependencies": {
+            "split": {
+              "version": "0.3.3",
+              "from": "split@>=0.3.0 <0.4.0",
+              "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+              "dependencies": {
+                "through": {
+                  "version": "2.3.8",
+                  "from": "through@>=2.0.0 <3.0.0",
+                  "resolved": "http://npm.internal.magnet.me:4873/through/-/through-2.3.8.tgz"
+                }
+              }
+            }
+          }
+        },
+        "semver": {
+          "version": "4.3.6",
+          "from": "semver@>=4.1.0 <5.0.0",
+          "resolved": "http://npm.internal.magnet.me:4873/semver/-/semver-4.3.6.tgz"
+        }
+      }
     },
     "pg-migration": {
       "version": "1.0.2",
-      "from": "pg-migration@>=1.0.1 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/pg-migration/-/pg-migration-1.0.2.tgz"
-    },
-    "pg-types": {
-      "version": "1.11.0",
-      "from": "pg-types@>=1.0.0 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/pg-types/-/pg-types-1.11.0.tgz"
-    },
-    "pgpass": {
-      "version": "0.0.3",
-      "from": "pgpass@0.0.3",
-      "resolved": "http://npm.internal.magnet.me:4873/pgpass/-/pgpass-0.0.3.tgz"
-    },
-    "pify": {
-      "version": "2.3.0",
-      "from": "pify@>=2.0.0 <3.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/pify/-/pify-2.3.0.tgz"
-    },
-    "pinkie": {
-      "version": "2.0.4",
-      "from": "pinkie@>=2.0.0 <3.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/pinkie/-/pinkie-2.0.4.tgz"
-    },
-    "pinkie-promise": {
-      "version": "2.0.1",
-      "from": "pinkie-promise@>=2.0.0 <3.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
-    },
-    "pluralize": {
-      "version": "1.2.1",
-      "from": "pluralize@>=1.2.1 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/pluralize/-/pluralize-1.2.1.tgz"
-    },
-    "postgres-array": {
-      "version": "1.0.0",
-      "from": "postgres-array@>=1.0.0 <1.1.0",
-      "resolved": "http://npm.internal.magnet.me:4873/postgres-array/-/postgres-array-1.0.0.tgz"
-    },
-    "postgres-bytea": {
-      "version": "1.0.0",
-      "from": "postgres-bytea@>=1.0.0 <1.1.0",
-      "resolved": "http://npm.internal.magnet.me:4873/postgres-bytea/-/postgres-bytea-1.0.0.tgz"
-    },
-    "postgres-date": {
-      "version": "1.0.2",
-      "from": "postgres-date@>=1.0.0 <1.1.0",
-      "resolved": "http://npm.internal.magnet.me:4873/postgres-date/-/postgres-date-1.0.2.tgz"
-    },
-    "postgres-interval": {
-      "version": "1.0.2",
-      "from": "postgres-interval@>=1.0.0 <1.1.0",
-      "resolved": "http://npm.internal.magnet.me:4873/postgres-interval/-/postgres-interval-1.0.2.tgz"
-    },
-    "prelude-ls": {
-      "version": "1.1.2",
-      "from": "prelude-ls@>=1.1.2 <1.2.0",
-      "resolved": "http://npm.internal.magnet.me:4873/prelude-ls/-/prelude-ls-1.1.2.tgz"
-    },
-    "preserve": {
-      "version": "0.2.0",
-      "from": "preserve@>=0.2.0 <0.3.0",
-      "resolved": "http://npm.internal.magnet.me:4873/preserve/-/preserve-0.2.0.tgz"
-    },
-    "private": {
-      "version": "0.1.6",
-      "from": "private@>=0.1.6 <0.2.0",
-      "resolved": "http://npm.internal.magnet.me:4873/private/-/private-0.1.6.tgz"
-    },
-    "process-nextick-args": {
-      "version": "1.0.7",
-      "from": "process-nextick-args@>=1.0.6 <1.1.0",
-      "resolved": "http://npm.internal.magnet.me:4873/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
-    },
-    "progress": {
-      "version": "1.1.8",
-      "from": "progress@>=1.1.8 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/progress/-/progress-1.1.8.tgz"
+      "from": "pg-migration@>=1.0.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/pg-migration/-/pg-migration-1.0.2.tgz",
+      "dependencies": {
+        "es6-promise": {
+          "version": "3.3.1",
+          "from": "es6-promise@>=3.0.2 <4.0.0",
+          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz"
+        },
+        "fs-extra": {
+          "version": "0.26.7",
+          "from": "fs-extra@>=0.26.4 <0.27.0",
+          "resolved": "http://npm.internal.magnet.me:4873/fs-extra/-/fs-extra-0.26.7.tgz",
+          "dependencies": {
+            "graceful-fs": {
+              "version": "4.1.11",
+              "from": "graceful-fs@>=4.1.2 <5.0.0",
+              "resolved": "http://npm.internal.magnet.me:4873/graceful-fs/-/graceful-fs-4.1.11.tgz"
+            },
+            "jsonfile": {
+              "version": "2.4.0",
+              "from": "jsonfile@>=2.1.0 <3.0.0",
+              "resolved": "http://npm.internal.magnet.me:4873/jsonfile/-/jsonfile-2.4.0.tgz"
+            },
+            "klaw": {
+              "version": "1.3.1",
+              "from": "klaw@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz"
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "from": "path-is-absolute@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+            },
+            "rimraf": {
+              "version": "2.5.4",
+              "from": "rimraf@>=2.2.8 <3.0.0",
+              "resolved": "http://npm.internal.magnet.me:4873/rimraf/-/rimraf-2.5.4.tgz",
+              "dependencies": {
+                "glob": {
+                  "version": "7.1.1",
+                  "from": "glob@>=7.0.5 <8.0.0",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+                  "dependencies": {
+                    "fs.realpath": {
+                      "version": "1.0.0",
+                      "from": "fs.realpath@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
+                    },
+                    "inflight": {
+                      "version": "1.0.6",
+                      "from": "inflight@>=1.0.4 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.2",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "http://npm.internal.magnet.me:4873/wrappy/-/wrappy-1.0.2.tgz"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.3",
+                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                    },
+                    "minimatch": {
+                      "version": "3.0.3",
+                      "from": "minimatch@>=3.0.2 <4.0.0",
+                      "resolved": "http://npm.internal.magnet.me:4873/minimatch/-/minimatch-3.0.3.tgz",
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.6",
+                          "from": "brace-expansion@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.4.2",
+                              "from": "balanced-match@>=0.4.1 <0.5.0",
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "from": "concat-map@0.0.1",
+                              "resolved": "http://npm.internal.magnet.me:4873/concat-map/-/concat-map-0.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.4.0",
+                      "from": "once@>=1.3.0 <2.0.0",
+                      "resolved": "http://npm.internal.magnet.me:4873/once/-/once-1.4.0.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.2",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "http://npm.internal.magnet.me:4873/wrappy/-/wrappy-1.0.2.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     },
     "promisify-node": {
       "version": "0.4.0",
       "from": "promisify-node@>=0.4.0 <0.5.0",
-      "resolved": "http://npm.internal.magnet.me:4873/promisify-node/-/promisify-node-0.4.0.tgz"
-    },
-    "proxy-addr": {
-      "version": "1.1.2",
-      "from": "proxy-addr@>=1.1.2 <1.2.0",
-      "resolved": "http://npm.internal.magnet.me:4873/proxy-addr/-/proxy-addr-1.1.2.tgz"
-    },
-    "qs": {
-      "version": "6.2.0",
-      "from": "qs@6.2.0",
-      "resolved": "http://npm.internal.magnet.me:4873/qs/-/qs-6.2.0.tgz"
-    },
-    "randomatic": {
-      "version": "1.1.5",
-      "from": "randomatic@>=1.1.3 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/randomatic/-/randomatic-1.1.5.tgz"
-    },
-    "range-parser": {
-      "version": "1.2.0",
-      "from": "range-parser@>=1.2.0 <1.3.0",
-      "resolved": "http://npm.internal.magnet.me:4873/range-parser/-/range-parser-1.2.0.tgz"
-    },
-    "raw-body": {
-      "version": "2.1.7",
-      "from": "raw-body@>=2.1.7 <2.2.0",
-      "resolved": "http://npm.internal.magnet.me:4873/raw-body/-/raw-body-2.1.7.tgz"
-    },
-    "read-json-sync": {
-      "version": "1.1.1",
-      "from": "read-json-sync@>=1.1.0 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/read-json-sync/-/read-json-sync-1.1.1.tgz"
-    },
-    "read-pkg": {
-      "version": "1.1.0",
-      "from": "read-pkg@>=1.0.0 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/read-pkg/-/read-pkg-1.1.0.tgz"
-    },
-    "read-pkg-up": {
-      "version": "1.0.1",
-      "from": "read-pkg-up@>=1.0.1 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/read-pkg-up/-/read-pkg-up-1.0.1.tgz"
-    },
-    "readable-stream": {
-      "version": "2.1.4",
-      "from": "readable-stream@>=2.0.2 <3.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/readable-stream/-/readable-stream-2.1.4.tgz"
-    },
-    "readdirp": {
-      "version": "2.1.0",
-      "from": "readdirp@>=2.0.0 <3.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/readdirp/-/readdirp-2.1.0.tgz"
-    },
-    "readline2": {
-      "version": "1.0.1",
-      "from": "readline2@>=1.0.1 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/readline2/-/readline2-1.0.1.tgz"
-    },
-    "redent": {
-      "version": "1.0.0",
-      "from": "redent@>=1.0.0 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/redent/-/redent-1.0.0.tgz"
-    },
-    "regenerate": {
-      "version": "1.3.1",
-      "from": "regenerate@>=1.2.1 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/regenerate/-/regenerate-1.3.1.tgz"
-    },
-    "regenerator-runtime": {
-      "version": "0.9.5",
-      "from": "regenerator-runtime@>=0.9.5 <0.10.0",
-      "resolved": "http://npm.internal.magnet.me:4873/regenerator-runtime/-/regenerator-runtime-0.9.5.tgz"
-    },
-    "regex-cache": {
-      "version": "0.4.3",
-      "from": "regex-cache@>=0.4.2 <0.5.0",
-      "resolved": "http://npm.internal.magnet.me:4873/regex-cache/-/regex-cache-0.4.3.tgz"
-    },
-    "regexpu-core": {
-      "version": "2.0.0",
-      "from": "regexpu-core@>=2.0.0 <3.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/regexpu-core/-/regexpu-core-2.0.0.tgz"
-    },
-    "regjsgen": {
-      "version": "0.2.0",
-      "from": "regjsgen@>=0.2.0 <0.3.0",
-      "resolved": "http://npm.internal.magnet.me:4873/regjsgen/-/regjsgen-0.2.0.tgz"
-    },
-    "regjsparser": {
-      "version": "0.1.5",
-      "from": "regjsparser@>=0.1.4 <0.2.0",
-      "resolved": "http://npm.internal.magnet.me:4873/regjsparser/-/regjsparser-0.1.5.tgz"
-    },
-    "repeat-element": {
-      "version": "1.1.2",
-      "from": "repeat-element@>=1.1.2 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/repeat-element/-/repeat-element-1.1.2.tgz"
-    },
-    "repeat-string": {
-      "version": "1.5.4",
-      "from": "repeat-string@>=1.5.2 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/repeat-string/-/repeat-string-1.5.4.tgz"
-    },
-    "repeating": {
-      "version": "1.1.3",
-      "from": "repeating@>=1.1.0 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/repeating/-/repeating-1.1.3.tgz"
-    },
-    "request": {
-      "version": "2.72.0",
-      "from": "request@>=2.65.0 <3.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/request/-/request-2.72.0.tgz",
+      "resolved": "https://registry.npmjs.org/promisify-node/-/promisify-node-0.4.0.tgz",
       "dependencies": {
-        "qs": {
-          "version": "6.1.0",
-          "from": "qs@>=6.1.0 <6.2.0",
-          "resolved": "http://npm.internal.magnet.me:4873/qs/-/qs-6.1.0.tgz"
+        "nodegit-promise": {
+          "version": "4.0.0",
+          "from": "nodegit-promise@>=4.0.0 <4.1.0",
+          "resolved": "http://npm.internal.magnet.me:4873/nodegit-promise/-/nodegit-promise-4.0.0.tgz",
+          "dependencies": {
+            "asap": {
+              "version": "2.0.5",
+              "from": "asap@>=2.0.3 <2.1.0",
+              "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz"
+            }
+          }
+        },
+        "object-assign": {
+          "version": "4.1.0",
+          "from": "object-assign@>=4.0.1 <5.0.0",
+          "resolved": "http://npm.internal.magnet.me:4873/object-assign/-/object-assign-4.1.0.tgz"
         }
       }
-    },
-    "require-uncached": {
-      "version": "1.0.2",
-      "from": "require-uncached@>=1.0.2 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/require-uncached/-/require-uncached-1.0.2.tgz"
-    },
-    "resolve-from": {
-      "version": "1.0.1",
-      "from": "resolve-from@>=1.0.0 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/resolve-from/-/resolve-from-1.0.1.tgz"
-    },
-    "restore-cursor": {
-      "version": "1.0.1",
-      "from": "restore-cursor@>=1.0.1 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/restore-cursor/-/restore-cursor-1.0.1.tgz"
-    },
-    "rimraf": {
-      "version": "2.5.2",
-      "from": "rimraf@>=2.2.8 <3.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/rimraf/-/rimraf-2.5.2.tgz"
-    },
-    "run-async": {
-      "version": "0.1.0",
-      "from": "run-async@>=0.1.0 <0.2.0",
-      "resolved": "http://npm.internal.magnet.me:4873/run-async/-/run-async-0.1.0.tgz"
-    },
-    "rx-lite": {
-      "version": "3.1.2",
-      "from": "rx-lite@>=3.1.2 <4.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/rx-lite/-/rx-lite-3.1.2.tgz"
-    },
-    "sax": {
-      "version": "1.1.5",
-      "from": "sax@1.1.5",
-      "resolved": "http://npm.internal.magnet.me:4873/sax/-/sax-1.1.5.tgz"
-    },
-    "semver": {
-      "version": "4.3.6",
-      "from": "semver@>=4.1.0 <5.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/semver/-/semver-4.3.6.tgz"
-    },
-    "semver-regex": {
-      "version": "1.0.0",
-      "from": "semver-regex@>=1.0.0 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/semver-regex/-/semver-regex-1.0.0.tgz"
-    },
-    "semver-truncate": {
-      "version": "1.1.0",
-      "from": "semver-truncate@>=1.0.0 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/semver-truncate/-/semver-truncate-1.1.0.tgz",
-      "dependencies": {
-        "semver": {
-          "version": "5.2.0",
-          "from": "semver@>=5.0.3 <6.0.0",
-          "resolved": "http://npm.internal.magnet.me:4873/semver/-/semver-5.2.0.tgz"
-        }
-      }
-    },
-    "send": {
-      "version": "0.14.1",
-      "from": "send@0.14.1",
-      "resolved": "http://npm.internal.magnet.me:4873/send/-/send-0.14.1.tgz"
-    },
-    "serve-static": {
-      "version": "1.11.1",
-      "from": "serve-static@>=1.11.1 <1.12.0",
-      "resolved": "http://npm.internal.magnet.me:4873/serve-static/-/serve-static-1.11.1.tgz"
-    },
-    "set-immediate-shim": {
-      "version": "1.0.1",
-      "from": "set-immediate-shim@>=1.0.1 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz"
-    },
-    "setprototypeof": {
-      "version": "1.0.1",
-      "from": "setprototypeof@1.0.1",
-      "resolved": "http://npm.internal.magnet.me:4873/setprototypeof/-/setprototypeof-1.0.1.tgz"
-    },
-    "shebang-regex": {
-      "version": "1.0.0",
-      "from": "shebang-regex@>=1.0.0 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/shebang-regex/-/shebang-regex-1.0.0.tgz"
-    },
-    "shelljs": {
-      "version": "0.6.0",
-      "from": "shelljs@>=0.6.0 <0.7.0",
-      "resolved": "http://npm.internal.magnet.me:4873/shelljs/-/shelljs-0.6.0.tgz"
-    },
-    "signal-exit": {
-      "version": "3.0.0",
-      "from": "signal-exit@>=3.0.0 <4.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/signal-exit/-/signal-exit-3.0.0.tgz"
-    },
-    "slash": {
-      "version": "1.0.0",
-      "from": "slash@>=1.0.0 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/slash/-/slash-1.0.0.tgz"
-    },
-    "slice-ansi": {
-      "version": "0.0.4",
-      "from": "slice-ansi@0.0.4",
-      "resolved": "http://npm.internal.magnet.me:4873/slice-ansi/-/slice-ansi-0.0.4.tgz"
-    },
-    "sntp": {
-      "version": "1.0.9",
-      "from": "sntp@>=1.0.0 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/sntp/-/sntp-1.0.9.tgz"
-    },
-    "source-map": {
-      "version": "0.5.6",
-      "from": "source-map@>=0.5.0 <0.6.0",
-      "resolved": "http://npm.internal.magnet.me:4873/source-map/-/source-map-0.5.6.tgz"
-    },
-    "source-map-support": {
-      "version": "0.2.10",
-      "from": "source-map-support@>=0.2.10 <0.3.0",
-      "resolved": "http://npm.internal.magnet.me:4873/source-map-support/-/source-map-support-0.2.10.tgz",
-      "dependencies": {
-        "source-map": {
-          "version": "0.1.32",
-          "from": "source-map@0.1.32",
-          "resolved": "http://npm.internal.magnet.me:4873/source-map/-/source-map-0.1.32.tgz"
-        }
-      }
-    },
-    "spdx-correct": {
-      "version": "1.0.2",
-      "from": "spdx-correct@>=1.0.0 <1.1.0",
-      "resolved": "http://npm.internal.magnet.me:4873/spdx-correct/-/spdx-correct-1.0.2.tgz"
-    },
-    "spdx-exceptions": {
-      "version": "1.0.4",
-      "from": "spdx-exceptions@>=1.0.4 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz"
-    },
-    "spdx-expression-parse": {
-      "version": "1.0.2",
-      "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
-      "resolved": "http://npm.internal.magnet.me:4873/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz"
-    },
-    "spdx-license-ids": {
-      "version": "1.2.1",
-      "from": "spdx-license-ids@>=1.0.2 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz"
-    },
-    "split": {
-      "version": "0.3.3",
-      "from": "split@>=0.3.0 <0.4.0",
-      "resolved": "http://npm.internal.magnet.me:4873/split/-/split-0.3.3.tgz"
-    },
-    "sprintf-js": {
-      "version": "1.0.3",
-      "from": "sprintf-js@>=1.0.2 <1.1.0",
-      "resolved": "http://npm.internal.magnet.me:4873/sprintf-js/-/sprintf-js-1.0.3.tgz"
-    },
-    "sshpk": {
-      "version": "1.8.3",
-      "from": "sshpk@>=1.7.0 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/sshpk/-/sshpk-1.8.3.tgz",
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "from": "assert-plus@>=1.0.0 <2.0.0",
-          "resolved": "http://npm.internal.magnet.me:4873/assert-plus/-/assert-plus-1.0.0.tgz"
-        }
-      }
-    },
-    "statuses": {
-      "version": "1.3.0",
-      "from": "statuses@>=1.3.0 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/statuses/-/statuses-1.3.0.tgz"
-    },
-    "string-width": {
-      "version": "1.0.1",
-      "from": "string-width@>=1.0.1 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/string-width/-/string-width-1.0.1.tgz"
-    },
-    "string_decoder": {
-      "version": "0.10.31",
-      "from": "string_decoder@>=0.10.0 <0.11.0",
-      "resolved": "http://npm.internal.magnet.me:4873/string_decoder/-/string_decoder-0.10.31.tgz"
-    },
-    "stringstream": {
-      "version": "0.0.5",
-      "from": "stringstream@>=0.0.4 <0.1.0",
-      "resolved": "http://npm.internal.magnet.me:4873/stringstream/-/stringstream-0.0.5.tgz"
-    },
-    "strip-ansi": {
-      "version": "3.0.1",
-      "from": "strip-ansi@>=3.0.0 <4.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/strip-ansi/-/strip-ansi-3.0.1.tgz"
-    },
-    "strip-bom": {
-      "version": "2.0.0",
-      "from": "strip-bom@>=2.0.0 <3.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/strip-bom/-/strip-bom-2.0.0.tgz"
-    },
-    "strip-indent": {
-      "version": "1.0.1",
-      "from": "strip-indent@>=1.0.1 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/strip-indent/-/strip-indent-1.0.1.tgz"
-    },
-    "strip-json-comments": {
-      "version": "1.0.4",
-      "from": "strip-json-comments@>=1.0.1 <1.1.0",
-      "resolved": "http://npm.internal.magnet.me:4873/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
-    },
-    "supports-color": {
-      "version": "2.0.0",
-      "from": "supports-color@>=2.0.0 <3.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/supports-color/-/supports-color-2.0.0.tgz"
-    },
-    "table": {
-      "version": "3.7.8",
-      "from": "table@>=3.7.8 <4.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/table/-/table-3.7.8.tgz",
-      "dependencies": {
-        "lodash": {
-          "version": "4.13.1",
-          "from": "lodash@>=4.0.0 <5.0.0",
-          "resolved": "http://npm.internal.magnet.me:4873/lodash/-/lodash-4.13.1.tgz"
-        }
-      }
-    },
-    "text-table": {
-      "version": "0.2.0",
-      "from": "text-table@>=0.2.0 <0.3.0",
-      "resolved": "http://npm.internal.magnet.me:4873/text-table/-/text-table-0.2.0.tgz"
-    },
-    "through": {
-      "version": "2.3.8",
-      "from": "through@>=2.0.0 <3.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/through/-/through-2.3.8.tgz"
-    },
-    "to-fast-properties": {
-      "version": "1.0.2",
-      "from": "to-fast-properties@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz"
-    },
-    "tough-cookie": {
-      "version": "2.2.2",
-      "from": "tough-cookie@>=2.2.0 <2.3.0",
-      "resolved": "http://npm.internal.magnet.me:4873/tough-cookie/-/tough-cookie-2.2.2.tgz"
-    },
-    "trim-newlines": {
-      "version": "1.0.0",
-      "from": "trim-newlines@>=1.0.0 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/trim-newlines/-/trim-newlines-1.0.0.tgz"
-    },
-    "tryit": {
-      "version": "1.0.2",
-      "from": "tryit@>=1.0.1 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/tryit/-/tryit-1.0.2.tgz"
-    },
-    "tunnel-agent": {
-      "version": "0.4.3",
-      "from": "tunnel-agent@>=0.4.1 <0.5.0",
-      "resolved": "http://npm.internal.magnet.me:4873/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
-    },
-    "tv4": {
-      "version": "1.2.7",
-      "from": "tv4@>=1.2.7 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/tv4/-/tv4-1.2.7.tgz"
-    },
-    "tweetnacl": {
-      "version": "0.13.3",
-      "from": "tweetnacl@>=0.13.0 <0.14.0",
-      "resolved": "http://npm.internal.magnet.me:4873/tweetnacl/-/tweetnacl-0.13.3.tgz"
-    },
-    "type-check": {
-      "version": "0.3.2",
-      "from": "type-check@>=0.3.2 <0.4.0",
-      "resolved": "http://npm.internal.magnet.me:4873/type-check/-/type-check-0.3.2.tgz"
-    },
-    "type-is": {
-      "version": "1.6.13",
-      "from": "type-is@>=1.6.13 <1.7.0",
-      "resolved": "http://npm.internal.magnet.me:4873/type-is/-/type-is-1.6.13.tgz"
-    },
-    "typedarray": {
-      "version": "0.0.6",
-      "from": "typedarray@>=0.0.5 <0.1.0",
-      "resolved": "http://npm.internal.magnet.me:4873/typedarray/-/typedarray-0.0.6.tgz"
-    },
-    "unpipe": {
-      "version": "1.0.0",
-      "from": "unpipe@1.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/unpipe/-/unpipe-1.0.0.tgz"
-    },
-    "user-home": {
-      "version": "1.1.1",
-      "from": "user-home@>=1.1.1 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/user-home/-/user-home-1.1.1.tgz"
-    },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "from": "util-deprecate@>=1.0.1 <1.1.0",
-      "resolved": "http://npm.internal.magnet.me:4873/util-deprecate/-/util-deprecate-1.0.2.tgz"
-    },
-    "utils-merge": {
-      "version": "1.0.0",
-      "from": "utils-merge@1.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/utils-merge/-/utils-merge-1.0.0.tgz"
     },
     "uuid": {
-      "version": "2.0.2",
-      "from": "uuid@>=2.0.2 <3.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/uuid/-/uuid-2.0.2.tgz"
-    },
-    "v8flags": {
-      "version": "2.0.11",
-      "from": "v8flags@>=2.0.10 <3.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/v8flags/-/v8flags-2.0.11.tgz"
-    },
-    "validate-npm-package-license": {
-      "version": "3.0.1",
-      "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz"
-    },
-    "vary": {
-      "version": "1.1.0",
-      "from": "vary@>=1.1.0 <1.2.0",
-      "resolved": "http://npm.internal.magnet.me:4873/vary/-/vary-1.1.0.tgz"
-    },
-    "verror": {
-      "version": "1.3.6",
-      "from": "verror@1.3.6",
-      "resolved": "http://npm.internal.magnet.me:4873/verror/-/verror-1.3.6.tgz"
-    },
-    "wordwrap": {
-      "version": "1.0.0",
-      "from": "wordwrap@>=1.0.0 <1.1.0",
-      "resolved": "http://npm.internal.magnet.me:4873/wordwrap/-/wordwrap-1.0.0.tgz"
-    },
-    "wrappy": {
-      "version": "1.0.2",
-      "from": "wrappy@>=1.0.0 <2.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/wrappy/-/wrappy-1.0.2.tgz"
-    },
-    "write": {
-      "version": "0.2.1",
-      "from": "write@>=0.2.1 <0.3.0",
-      "resolved": "http://npm.internal.magnet.me:4873/write/-/write-0.2.1.tgz"
-    },
-    "xml2js": {
-      "version": "0.4.15",
-      "from": "xml2js@0.4.15",
-      "resolved": "http://npm.internal.magnet.me:4873/xml2js/-/xml2js-0.4.15.tgz"
-    },
-    "xmlbuilder": {
-      "version": "2.6.2",
-      "from": "xmlbuilder@2.6.2",
-      "resolved": "http://npm.internal.magnet.me:4873/xmlbuilder/-/xmlbuilder-2.6.2.tgz"
-    },
-    "xregexp": {
-      "version": "3.1.1",
-      "from": "xregexp@>=3.0.0 <4.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/xregexp/-/xregexp-3.1.1.tgz"
-    },
-    "xtend": {
-      "version": "4.0.1",
-      "from": "xtend@>=4.0.0 <5.0.0",
-      "resolved": "http://npm.internal.magnet.me:4873/xtend/-/xtend-4.0.1.tgz"
+      "version": "2.0.3",
+      "from": "uuid@>=2.0.3 <3.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,17 +4,17 @@
   "description": "ImageMagick as a HTTP service, using AWS S3 to store caches",
   "main": "src/index.js",
   "dependencies": {
-    "aws-sdk": "^2.2.26",
-    "babel-polyfill": "^6.9.1",
-    "body-parser": "^1.14.2",
-    "config": "^1.17.1",
-    "express": "^4.13.3",
+    "aws-sdk": "^2.6.15",
+    "babel-polyfill": "^6.13.0",
+    "body-parser": "^1.15.2",
+    "config": "^1.24.0",
+    "express": "^4.14.0",
     "formidable": "^1.0.17",
-    "gm": "^1.22.0",
+    "gm": "^1.23.0",
     "pg": "^4.4.3",
-    "pg-migration": "^1.0.1",
-    "uuid": "^2.0.2",
-    "promisify-node": "^0.4.0"
+    "pg-migration": "^1.0.2",
+    "promisify-node": "^0.4.0",
+    "uuid": "^2.0.3"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
@@ -39,11 +39,11 @@
   },
   "homepage": "https://github.com/inventid/iaas",
   "devDependencies": {
-    "babel-cli": "^6.4",
-    "babel-eslint": "^6.1.0",
-    "babel-preset-es2015": "^6.3",
-    "babel-preset-stage-3": "^6.11.0",
-    "eslint": "^2.13.1",
+    "babel-cli": "^6.18",
+    "babel-eslint": "^7.1.1",
+    "babel-preset-es2015": "^6.18",
+    "babel-preset-stage-3": "^6.17.0",
+    "eslint": "^3.12.1",
     "eslint-plugin-async-await": "0.0.0"
   }
 }

--- a/shippable.yml
+++ b/shippable.yml
@@ -1,4 +1,6 @@
 language: node_js
+node_js:
+  - 6
 
 notifications:
   email: false

--- a/src/aws.js
+++ b/src/aws.js
@@ -11,7 +11,7 @@ AWS.config.update({
 });
 const S3 = new AWS.S3();
 
-const upload = (client, params) => {
+const upload = async(client, params) => {
   return new Promise((resolve, reject) => client.putObject(params, err => err ? reject(err) : resolve()));
 };
 

--- a/src/aws.js
+++ b/src/aws.js
@@ -11,7 +11,7 @@ AWS.config.update({
 });
 const S3 = new AWS.S3();
 
-const upload = async(client, params) => {
+const upload = (client, params) => {
   return new Promise((resolve, reject) => client.putObject(params, err => err ? reject(err) : resolve()));
 };
 

--- a/src/image.js
+++ b/src/image.js
@@ -60,7 +60,7 @@ const clip = async(client, params) => {
 
 const cover = async(client, params) => {
   return client.resize(params.width, params.height, '^');
-}
+};
 
 // Same as clipping, however the remainder of the bounding box is filled with
 // white.


### PR DESCRIPTION
@TiddoLangerak I shrinkwrapped incorrectly, using our internal registry as a dependency (failing all CI builds)

However if I try to build with the latest versions, babel errors with 

```
Error: aws.js: You gave us a visitor for the node type "ForAwaitStatement" but it's not a valid type
    at verify (/usr/local/lib/node_modules/babel-cli/node_modules/babel-traverse/lib/visitors.js:224:13)
    at Object.explode (/usr/local/lib/node_modules/babel-cli/node_modules/babel-traverse/lib/visitors.js:90:3)
    at traverse (/usr/local/lib/node_modules/babel-cli/node_modules/babel-traverse/lib/index.js:81:12)
    at NodePath.traverse (/usr/local/lib/node_modules/babel-cli/node_modules/babel-traverse/lib/path/index.js:147:25)
    at exports.default (/opt/iaas/node_modules/babel-preset-stage-3/node_modules/babel-helper-remap-async-to-generator/lib/index.js:10:8)
    at PluginPass.Function (/opt/iaas/node_modules/babel-preset-stage-3/node_modules/babel-plugin-transform-async-to-generator/lib/index.js:13:56)
    at newFn (/usr/local/lib/node_modules/babel-cli/node_modules/babel-traverse/lib/visitors.js:301:19)
    at NodePath._call (/usr/local/lib/node_modules/babel-cli/node_modules/babel-traverse/lib/path/context.js:76:18)
    at NodePath.call (/usr/local/lib/node_modules/babel-cli/node_modules/babel-traverse/lib/path/context.js:48:17)
    at NodePath.visit (/usr/local/lib/node_modules/babel-cli/node_modules/babel-traverse/lib/path/context.js:106:12)
```

Any idea what might be off?