### PR TITLE
Additional error logging on losing processes

### DIFF
--- a/src/imageResponse.js
+++ b/src/imageResponse.js
@@ -132,15 +132,21 @@ export default {
         log('error', `Error occurred while creating live image: ${err}`);
         return;
       }
+      const errors = [];
       const r = stdout.pipe(response);
       r.on('finish', () => {
-        log('info', `Creating live image took ${new Date() - clientStartTime}ms: ${params.name}.${params.type} (${params.width}x${params.height}px, fit: ${params.fit}, blur: ${Boolean(params.blur)})`);  //eslint-disable-line max-len
+	    if (errors.length === 0) {
+          log('info', `Creating live image took ${new Date() - clientStartTime}ms: ${params.name}.${params.type} (${params.width}x${params.height}px, fit: ${params.fit}, blur: ${Boolean(params.blur)})`);  //eslint-disable-line max-len
+        } else {
+          log('warn', `Got an error while creating live image. Took ${new Date() - clientStartTime}ms: ${params.name}.${params.type} (${params.width}x${params.height}px, fit: ${params.fit}, blur: ${Boolean(params.blur)})`);  //eslint-disable-line max-len
+        }
         // This is to close the response while a background job will continue to process
         response.end();
       });
       r.on('error', (error) => {
-        log('error', `The live image stream errorred with ${error}`);
-        response.end();
+        log('error', `The live image stream hit an error: ${error}`);
+        stdout.pipe(response);
+        errors.push(error);
         r.end();
       });
     });

--- a/src/imageResponse.js
+++ b/src/imageResponse.js
@@ -127,7 +127,7 @@ export default {
     const clientStartTime = new Date();
     const browserImage = await image.magic(imagePath(params.name), params, response);
     browserImage.stream(params.type, (err, stdout) => {
-      if(err) {
+      if (err) {
         response.status(500).end();
         log('error', `Error occurred while creating live image: ${err}`);
         return;
@@ -135,7 +135,7 @@ export default {
       const errors = [];
       const r = stdout.pipe(response);
       r.on('finish', () => {
-	    if (errors.length === 0) {
+        if (errors.length === 0) {
           log('info', `Creating live image took ${new Date() - clientStartTime}ms: ${params.name}.${params.type} (${params.width}x${params.height}px, fit: ${params.fit}, blur: ${Boolean(params.blur)})`);  //eslint-disable-line max-len
         } else {
           log('warn', `Got an error while creating live image. Took ${new Date() - clientStartTime}ms: ${params.name}.${params.type} (${params.width}x${params.height}px, fit: ${params.fit}, blur: ${Boolean(params.blur)})`);  //eslint-disable-line max-len

--- a/src/imageResponse.js
+++ b/src/imageResponse.js
@@ -145,7 +145,7 @@ export default {
       });
       r.on('error', (error) => {
         log('error', `The live image stream hit an error: ${error}`);
-        stdout.pipe(response);
+        stdout.unpipe(response);
         errors.push(error);
         r.end();
       });

--- a/src/imageResponse.js
+++ b/src/imageResponse.js
@@ -127,11 +127,21 @@ export default {
     const clientStartTime = new Date();
     const browserImage = await image.magic(imagePath(params.name), params, response);
     browserImage.stream(params.type, (err, stdout) => {
+      if(err) {
+        response.status(500).end();
+        log('error', `Error occurred while creating live image: ${err}`);
+        return;
+      }
       const r = stdout.pipe(response);
       r.on('finish', () => {
         log('info', `Creating live image took ${new Date() - clientStartTime}ms: ${params.name}.${params.type} (${params.width}x${params.height}px, fit: ${params.fit}, blur: ${Boolean(params.blur)})`);  //eslint-disable-line max-len
         // This is to close the response while a background job will continue to process
         response.end();
+      });
+      r.on('error', (error) => {
+        log('error', `The live image stream errorred with ${error}`);
+        response.end();
+        r.end();
       });
     });
 


### PR DESCRIPTION
It seems that the iaas processes loses some convert processes. While running for slightly over 12 hour, we have 84 of these processes open.

Logging indicates that for these images the AWS images were created successfully, but the live images do not report success. I suspect this is because the client has moved to another page before the image was resized, and therefore the pipe into the response fails (since the client has disconnected). Additionally since the stream is not closed on an error, this process remains open.

In order to investigate, I want to log any errors in that part of the sending. In case the stream did error, we close both the response and the stream.

There are two possible outcomes for this fix:

1. We do no longer see an ever increasing amount of convert processes. Logging indicates that the streams errored (due to disconnects). In that case we can remove the logging, and simply keep closing the responses and streams
1. The error is triggered while generating the image. This might indicate a bug in handling the data

@TiddoLangerak What is your opinion on this?