### PR TITLE
Handle browser disconnection while live live conversion is running

### DIFF
--- a/src/dbCache.js
+++ b/src/dbCache.js
@@ -26,7 +26,7 @@ export default (db) => {
         // Cache miss
         return null;
       } catch (e) {
-        log('error', e.stack);
+        log('error', e.toString());
         return null;
       }
     },
@@ -45,7 +45,7 @@ export default (db) => {
         const result = await promiseQuery(insertImage, vars);
         return result.rowCount === 1;
       } catch (e) {
-        log('error', JSON.stringify(e));
+        log('error', e.toString());
         return false;
       }
     }

--- a/src/dbCache.js
+++ b/src/dbCache.js
@@ -45,7 +45,7 @@ export default (db) => {
         const result = await promiseQuery(insertImage, vars);
         return result.rowCount === 1;
       } catch (e) {
-        log('error', e.stack);
+        log('error', JSON.stringify(e));
         return false;
       }
     }

--- a/src/index.js
+++ b/src/index.js
@@ -104,12 +104,12 @@ server.get('/robots.txt', (req, res) => {
 server.get('/(:name)_(:width)_(:height)_(:scale)x.(:format)', (req, res) => {
   // Serve a resized image with scaling
   const params = urlParameters(req);
-  imageResponse.magic(db, params, req.method, res);
+  imageResponse.magic(db, params, req.method, res, req);
 });
 server.get('/(:name)_(:width)_(:height).(:format)', (req, res) => {
   // Serve a resized image
   const params = urlParameters(req);
-  imageResponse.magic(db, params, req.method, res);
+  imageResponse.magic(db, params, req.method, res, req);
 });
 server.get('/(:name).(:format)', (req, res) => {
   // Serve the original


### PR DESCRIPTION
This should effectively handle browsers which "give up" on a resource before its completed. The stream is properly terminated, so the convert process is cleaned up

@TiddoLangerak 