### PR TITLE
Only flatten the image after it has been cropped

### DIFF
--- a/src/image.js
+++ b/src/image.js
@@ -102,8 +102,8 @@ const blur = async(client, params) => {
 export default {
   magic: async function (file, params) {
     let client = im(file);
-    client = await background(client, params);
     client = await fit(client, params);
+    client = await background(client, params);
     client = await blur(client, params);
     client = await interlace(client, params);
     return client;


### PR DESCRIPTION
The filling of a transparent background for JPG requests should only happen after the fitting has taken place, otherwise the fitting can be done incorrectly