### PR TITLE
Allow image actions to time out after a while

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ The following settings are supported:
 | constraints.max_height | The maximum allowed height of the image. If a request is made that succeeds this height then a redirect is issued to an equivalent image within bounds. |
 | log.[level] | Whether to enable logs generated with the specified level, Where level is one of debug, info, warn or error. |
 | redirect_cache_timeout | Cache age in seconds of redirects to AWS. This value is used as the max-age in the Cache-Control header |
+| timeout.conversion | After which amount of milliseconds should any image process be terminated. Set to 0 to disable timeouts | 
 
 ### Database
 

--- a/config/default.json.example
+++ b/config/default.json.example
@@ -22,5 +22,8 @@
   "log": {
     "debug": false
   },
-  "redirect_cache_timeout" : 604800
+  "redirect_cache_timeout" : 604800,
+  "timeout": {
+    "conversion": 0
+  }
 }


### PR DESCRIPTION
Sometimes gm can hang, bringing down the machine it is hosted on. By adding a timeout to the image actions, we will kill the process and return an error to the requester

