### PR TITLE
Add support for JPG compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ All options for requesting are chainable.
 | Cover | GET `/example_100_100.jpg?fit=cover` | The image is resized where the requested sizes function as a minimum instead of a maximum |
 | Blurring | GET `/example_100_100.jpg?blur=true` | The image is blurred slightly |
 | Crop on upload | POST `/example.jpg?x=30&y=40&width=100&height=200` | The image original is saved after cropping by the suggested parameters |
+| Change image size & quality | Usage GET `/example_100_100.jpg?quality=75` | Change image size and quality. This is a number between 0 and 100 inclusive, or auto (default). When set to auto then the quality of the original image is preserved (note that this is not necessarily equal to 100). This option only works for JPG images, it has no effect on other images. |
 
 
 ## How to use
@@ -114,7 +115,7 @@ The following settings are supported:
 | constraints.max_height | The maximum allowed height of the image. If a request is made that succeeds this height then a redirect is issued to an equivalent image within bounds. |
 | log.[level] | Whether to enable logs generated with the specified level, Where level is one of debug, info, warn or error. |
 | redirect_cache_timeout | Cache age in seconds of redirects to AWS. This value is used as the max-age in the Cache-Control header |
-| timeout.conversion | After which amount of milliseconds should any image process be terminated. Set to 0 to disable timeouts | 
+| timeout.conversion | After which amount of milliseconds should any image process be terminated. Set to 0 to disable timeouts |
 
 ### Database
 

--- a/migrations/20170704100751.sql
+++ b/migrations/20170704100751.sql
@@ -1,0 +1,4 @@
+ALTER TABLE images ADD COLUMN quality INT;
+DROP INDEX unique_image;
+
+CREATE UNIQUE INDEX unique_image ON images(id,x,y,fit,file_type,blur,quality);

--- a/src/aws.js
+++ b/src/aws.js
@@ -17,7 +17,13 @@ const upload = (client, params) => {
 
 
 // TODO: Switch to aws.cache_host only soon
-const cacheHost = () => config.get('aws.cache_host') || config.get('aws.bucket_url');
+const cacheHost = () => {
+  if (config.has('aws.cache_host')) {
+    return config.get('aws.cache_host');
+  } else {
+    return config.get('aws.bucket_url');
+  }
+};
 
 export default (cache) => async(name, params, data) => {
   // See https://github.com/inventid/iaas/issues/78

--- a/src/dbCache.js
+++ b/src/dbCache.js
@@ -1,7 +1,21 @@
 import log from "./log";
 
-const insertImage = 'INSERT INTO images (id, x, y, fit, file_type, url, blur, rendered_at) VALUES ($1,$2,$3,$4,$5,$6,$7,$8)';
-const selectImage = 'SELECT url FROM images WHERE id=$1 AND x=$2 AND y=$3 AND fit=$4 AND file_type=$5 AND blur=$6';
+const insertImage = 'INSERT INTO images (id, x, y, fit, file_type, url, blur, quality, rendered_at) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)';
+const selectImage = 'SELECT url FROM images WHERE id=$1 AND x=$2 AND y=$3 AND fit=$4 AND file_type=$5 AND blur=$6 AND quality=$7';
+
+/**
+ * Returns the quality if set explicitly, or null if auto. This is done such
+ * that we can keep the DB field as an integer.
+ *
+ * @param {number|'auto'} quality The quality of the image
+ * @returns {number?} The quality if a number, of null if auto
+ */
+function qualityOrNull(quality) {
+  if (Number.isFinite(quality)) {
+    return quality;
+  }
+  return null;
+}
 
 export default (db) => {
   const promiseQuery = (query, vars) => {
@@ -14,7 +28,8 @@ export default (db) => {
         params.height,
         params.fit,
         params.mime,
-        Boolean(params.blur)
+        Boolean(params.blur),
+        qualityOrNull(params.quality)
       ];
 
       try {
@@ -38,6 +53,7 @@ export default (db) => {
         params.mime,
         url,
         Boolean(params.blur),
+        qualityOrNull(params.quality),
         renderedAt
       ];
 

--- a/src/urlParameters.js
+++ b/src/urlParameters.js
@@ -21,6 +21,10 @@ const getMimeFromExtension = (extension) => {
   }
 };
 
+export function hasFiltersApplied(params) {
+  return Boolean(params.blur) || Number.isFinite(params.quality);
+}
+
 export default (req, requireDimensions = true) => {
   // The default settings
   const result = {
@@ -30,7 +34,8 @@ export default (req, requireDimensions = true) => {
     blur: null,
     type: 'jpg',
     mime: 'image/jpeg',
-    fit: 'clip'
+    fit: 'clip',
+    quality: 'auto'
   };
 
   // Extract data
@@ -38,6 +43,7 @@ export default (req, requireDimensions = true) => {
   const scale = Number(req.params.scale) || 1;
   result.width = Number(req.params.width) * scale || undefined;
   result.height = Number(req.params.height) * scale || undefined;
+  result.quality = Number(req.query.quality) || 'auto';
 
   if (ALLOWED_TYPES.includes(req.params.format.toLowerCase())) {
     result.type = req.params.format.toLowerCase();


### PR DESCRIPTION
This adds support for an optional `?quality` parameter that allows
compressing jpegs. I experimented with a small set of images and found
that with `?quality=60` you reduce the filesize by more than half with
barely any noticeable difference.

This change also comes with another small fly-by: previously when no
explicit dimensions where given then the original file would be
returned, regardless of query parameters (e.g. blur wouldn't be taken
into account). Now, the dimensionless url will detect the blur and
quality filters and redirect to the maximum supported size image with
the filters applied.

@rogierslag can you review and perhaps also test it out locally to double check I didn't make mistakes?