### PR TITLE
Fix quality determination

### DIFF
--- a/migrations/20170704100751.sql
+++ b/migrations/20170704100751.sql
@@ -1,4 +1,4 @@
-ALTER TABLE images ADD COLUMN quality INT;
+ALTER TABLE images ADD COLUMN quality INT NOT NULL DEFAULT -1;
 DROP INDEX unique_image;
 
 CREATE UNIQUE INDEX unique_image ON images(id,x,y,fit,file_type,blur,quality);

--- a/src/dbCache.js
+++ b/src/dbCache.js
@@ -1,21 +1,7 @@
 import log from "./log";
 
 const insertImage = 'INSERT INTO images (id, x, y, fit, file_type, url, blur, quality, rendered_at) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)';
-const selectImage = 'SELECT url FROM images WHERE id=$1 AND x=$2 AND y=$3 AND fit=$4 AND file_type=$5 AND blur=$6 AND quality IS NOT DISTINCT FROM $7'; //eslint-disable-line max-len
-
-/**
- * Returns the quality if set explicitly, or null if auto. This is done such
- * that we can keep the DB field as an integer.
- *
- * @param {number|'auto'} quality The quality of the image
- * @returns {number?} The quality if a number, of null if auto
- */
-function qualityOrNull(quality) {
-  if (Number.isFinite(quality)) {
-    return quality;
-  }
-  return null;
-}
+const selectImage = 'SELECT url FROM images WHERE id=$1 AND x=$2 AND y=$3 AND fit=$4 AND file_type=$5 AND blur=$6 AND quality=$7'; //eslint-disable-line max-len
 
 export default (db) => {
   const promiseQuery = (query, vars) => {
@@ -29,12 +15,12 @@ export default (db) => {
         params.fit,
         params.mime,
         Boolean(params.blur),
-        qualityOrNull(params.quality)
+        params.quality
       ];
 
       try {
         const result = await promiseQuery(selectImage, vars);
-        if (result.rowCount && result.rowCount === 1) {
+        if (result.rowCount && result.rowCount > 0) {
           // Cache hit
           return result.rows[0].url;
         }
@@ -53,7 +39,7 @@ export default (db) => {
         params.mime,
         url,
         Boolean(params.blur),
-        qualityOrNull(params.quality),
+        params.quality,
         renderedAt
       ];
 

--- a/src/image.js
+++ b/src/image.js
@@ -113,8 +113,7 @@ const fit = async(client, params) => {
 };
 
 const setQuality = async(client, params) => {
-  const quality = Number(params.quality);
-  if (!quality) {
+  if (params.quality === -1) {
     return client;
   }
 
@@ -123,7 +122,7 @@ const setQuality = async(client, params) => {
   // through. For now, we only support jpg compression, which is the most intuitive.
   switch (params.mime) {
     case 'image/jpeg':
-      return client.quality(Math.min(100, Math.max(0, quality)));
+      return client.quality(Math.min(100, Math.max(0, params.quality)));
     default:
       //No compression supported for other types
       return client;

--- a/src/urlParameters.js
+++ b/src/urlParameters.js
@@ -35,7 +35,7 @@ export default (req, requireDimensions = true) => {
     type: 'jpg',
     mime: 'image/jpeg',
     fit: 'clip',
-    quality: 'auto'
+    quality: -1
   };
 
   // Extract data
@@ -43,7 +43,6 @@ export default (req, requireDimensions = true) => {
   const scale = Number(req.params.scale) || 1;
   result.width = Number(req.params.width) * scale || undefined;
   result.height = Number(req.params.height) * scale || undefined;
-  result.quality = Number(req.query.quality) || 'auto';
 
   if (ALLOWED_TYPES.includes(req.params.format.toLowerCase())) {
     result.type = req.params.format.toLowerCase();
@@ -51,6 +50,10 @@ export default (req, requireDimensions = true) => {
   }
   if (req.query.fit && ALLOWED_FITS.includes(req.query.fit.toLowerCase())) {
     result.fit = req.query.fit.toLowerCase();
+  }
+  // Only do this for jpg and ignore it for all other formats
+  if (req.query.quality && result.mime === 'image/jpeg') {
+	  result.quality = Number(req.query.quality) || -1;
   }
   if (req.query.blur && req.query.blur === 'true') {
     result.blur = {


### PR DESCRIPTION
if a column for postgresql is NULL the unique index does not hold.
Hence multiple things could be included, and due to the fact that we
checked on exactly one result, we would always fall through.

So I moved everything back to integers which is more suitable anyhow

```
imageresizer=# \d images;
                          Table "public.images"
   Column    |           Type           |           Modifiers            
-------------+--------------------------+--------------------------------
 id          | character varying(255)   | 
 x           | integer                  | 
 y           | integer                  | 
 fit         | character varying(8)     | 
 file_type   | character varying(16)    | 
 url         | character varying(255)   | 
 blur        | boolean                  | default false
 rendered_at | timestamp with time zone | 
 quality     | integer                  | not null default '-1'::integer

imageresizer=# select * from images;
      id      |  x  |  y   | fit  | file_type  |                                                   url                                                    | blur |        rendered_at         | quality 
--------------+-----+------+------+------------+----------------------------------------------------------------------------------------------------------+------+----------------------------+---------
 test12345678 | 100 |  100 | clip | image/jpeg | https://dn8z8vrzhrhua.cloudfront.net/2017-07-03T09:46:01.680Z_test12345678_100x100.clip.b-false.jpg      | f    | 2017-07-03 09:46:01.68+00  |      -1
 test12345678 | 100 |  100 | clip | image/jpeg | https://dn8z8vrzhrhua.cloudfront.net/2017-07-04T12:54:03.029Z_test12345678_100x100.clip.b-false.q-1.jpg  | f    | 2017-07-04 12:54:03.029+00 |      -1
 test123456   | 640 | 1136 | clip | image/png  | https://dn8z8vrzhrhua.cloudfront.net/2017-07-04T12:55:08.828Z_test123456_640x1136.clip.b-false.q-10.png  | f    | 2017-07-04 12:55:08.828+00 |      -1
 test123456   | 100 |  100 | clip | image/png  | https://dn8z8vrzhrhua.cloudfront.net/2017-07-04T12:58:59.968Z_test123456_100x100.clip.b-false.q-10.png   | f    | 2017-07-04 12:58:59.968+00 |      -1
 test123456   | 100 |  100 | clip | image/jpeg | https://dn8z8vrzhrhua.cloudfront.net/2017-07-04T12:59:06.657Z_test123456_100x100.clip.b-false.q-10.jpg   | f    | 2017-07-04 12:59:06.657+00 |      -1
 test123456   | 100 |  100 | clip | image/png  | https://dn8z8vrzhrhua.cloudfront.net/2017-07-04T12:59:50.818Z_test123456_100x100.clip.b-false.q-auto.png | f    | 2017-07-04 12:59:50.818+00 |      -1
 test123456   | 100 |  100 | clip | image/jpeg | https://dn8z8vrzhrhua.cloudfront.net/2017-07-04T13:00:06.980Z_test123456_100x100.clip.b-false.q-auto.jpg | f    | 2017-07-04 13:00:06.98+00  |      -1
 test123456   | 100 |  100 | clip | image/jpeg | https://dn8z8vrzhrhua.cloudfront.net/2017-07-04T13:00:04.708Z_test123456_100x100.clip.b-false.q-auto.jpg | f    | 2017-07-04 13:00:04.708+00 |      -1
 test123456   | 100 |  100 | clip | image/jpeg | https://dn8z8vrzhrhua.cloudfront.net/2017-07-04T13:00:29.133Z_test123456_100x100.clip.b-false.q-auto.jpg | f    | 2017-07-04 13:00:29.133+00 |      -1
 test123456   | 100 |  100 | clip | image/jpeg | https://dn8z8vrzhrhua.cloudfront.net/2017-07-04T13:01:43.029Z_test123456_100x100.clip.b-false.q-auto.jpg | f    | 2017-07-04 13:01:43.029+00 |      -1
 test123456   | 100 |  100 | clip | image/jpeg | https://dn8z8vrzhrhua.cloudfront.net/2017-07-04T13:01:44.320Z_test123456_100x100.clip.b-false.q-auto.jpg | f    | 2017-07-04 13:01:44.32+00  |      -1
 test123456   | 100 |  100 | clip | image/jpeg | https://dn8z8vrzhrhua.cloudfront.net/2017-07-04T13:01:45.206Z_test123456_100x100.clip.b-false.q-auto.jpg | f    | 2017-07-04 13:01:45.206+00 |      -1
 test123456   | 100 |  100 | clip | image/jpeg | https://dn8z8vrzhrhua.cloudfront.net/2017-07-04T13:09:03.397Z_test123456_100x100.clip.b-false.q--1.jpg   | f    | 2017-07-04 13:09:03.397+00 |      -1
 test123456   | 100 |  100 | clip | image/jpeg | https://dn8z8vrzhrhua.cloudfront.net/2017-07-04T13:09:10.448Z_test123456_100x100.clip.b-false.q--1.jpg   | f    | 2017-07-04 13:09:10.448+00 |      -1
 test123456   | 100 |  100 | clip | image/png  | https://dn8z8vrzhrhua.cloudfront.net/2017-07-04T13:09:16.290Z_test123456_100x100.clip.b-false.q--1.png   | f    | 2017-07-04 13:09:16.29+00  |      -1
 test123456   | 100 |  100 | clip | image/png  | https://dn8z8vrzhrhua.cloudfront.net/2017-07-04T13:09:20.018Z_test123456_100x100.clip.b-false.q--1.png   | f    | 2017-07-04 13:09:20.018+00 |      -1
 test123456   | 100 |  100 | clip | image/png  | https://dn8z8vrzhrhua.cloudfront.net/2017-07-04T13:09:26.663Z_test123456_100x100.clip.b-false.q--1.png   | f    | 2017-07-04 13:09:26.663+00 |      -1
(17 rows)
```