### PR TITLE
Log stats for hits and miss ratios

### DIFF
--- a/src/imageResponse.js
+++ b/src/imageResponse.js
@@ -96,7 +96,7 @@ const imageKey = params =>
 
 
 export default {
-  magic: async function (db, params, method, response) {
+  magic: async function (db, params, method, response, stats = undefined) {
     const cache = dbCache(db);
     if (params === null) {
       // Invalid, hence reject
@@ -129,8 +129,14 @@ export default {
     const cacheValue = await cache.getFromCache(params);
     if (cacheValue) {
       log('debug', `Cache hit for ${imageDescription}`);
+      if (stats) {
+        stats.hits.incrementAndGet();
+      }
       redirectToCachedEntity(cacheValue, params, response);
       return;
+    }
+    if (stats) {
+      stats.misses.incrementAndGet();
     }
 
     // Image is present but not in the correct setting

--- a/src/integerCounter.js
+++ b/src/integerCounter.js
@@ -1,0 +1,37 @@
+export default function integerCounter() {
+	let i = 0;
+
+	function incrementAndGet() {
+		i = i + 1;
+		return i;
+	}
+
+	function decrementAndGet() {
+		i = i - 1;
+		return i;
+	}
+
+	function getAndIncrement() {
+		const tmp = i;
+		i = i + 1;
+		return tmp;
+	}
+
+	function getAndDecrement() {
+		const tmp = i;
+		i = i - 1;
+		return tmp;
+	}
+
+	function get() {
+		return i;
+	}
+
+	return {
+		incrementAndGet,
+		decrementAndGet,
+		getAndIncrement,
+		getAndDecrement,
+		get
+	};
+}

--- a/src/log.js
+++ b/src/log.js
@@ -2,6 +2,7 @@ import config from 'config';
 
 const logLevels = {
   debug: config.has('log.debug') ? Boolean(config.get('log.debug')) : false,
+  stats: config.has('log.stats') ? Boolean(config.get('log.stats')) : false,
   info: config.has('log.info') ? Boolean(config.get('log.info')) : true,
   warn: config.has('log.warn') ? Boolean(config.get('log.warn')) : true,
   error: config.has('log.error') ? Boolean(config.get('log.error')) : true

--- a/src/urlParameters.js
+++ b/src/urlParameters.js
@@ -53,7 +53,7 @@ export default (req, requireDimensions = true) => {
   }
   // Only do this for jpg and ignore it for all other formats
   if (req.query.quality && result.mime === 'image/jpeg') {
-	  result.quality = Number(req.query.quality) || -1;
+    result.quality = Number(req.query.quality) || -1;
   }
   if (req.query.blur && req.query.blur === 'true') {
     result.blur = {


### PR DESCRIPTION
When enabled, this PR ensures that every 5 minutes each [PM2](http://npmjs.org/pm2) instance will report the following data:

1. Number of cache hits
1. Number of cache misses which triggered generations
1. Average number of generations per minute
1. Cache hit ratio

Note that if there is a reverse proxy before the iaas, many cache hits will be served by that service. The `generationsPerMinute` flag can be used to determine how heavily the resizing is hit.