### PR TITLE
Timeout metrics

### DIFF
--- a/src/databases/postgresql.js
+++ b/src/databases/postgresql.js
@@ -129,8 +129,13 @@ export default function postgresql() {
     });
   }
 
+  async function close() {
+    return await pool.end();
+  }
+
   return {
     migrate,
+    close,
     isDbAlive,
     createToken,
     consumeToken,

--- a/src/imageResponse.js
+++ b/src/imageResponse.js
@@ -16,7 +16,10 @@ const imagePath = (name) => `${config.get('originals_dir')}/${name}`;
 
 const redirectTimeout = config.has('redirect_cache_timeout') ? config.get('redirect_cache_timeout') : 0;
 
-const didTimeout = (error) => error.message === 'gm() resulted in a timeout.';
+const didTimeout = (error) => {
+  console.log(error.message);
+  return error.message === 'gm() resulted in a timeout.';
+};
 
 // Determine whether the image exists on disk
 // Returns either true of false
@@ -166,24 +169,13 @@ export default {
     sendFoundHeaders(params, response);
 
     const clientStartTime = new Date();
-    let browserImage;
-    try {
-      browserImage = await image.magic(imagePath(params.name), params);
-    } catch (e) {
-      const status = didTimeout(e) ? 504 : 500;
-      if (metric) {
-        metric.stop();
-        metric.addTag('status', status);
-        metrics.write(metric);
-        metrics.write(metric.copy(GENERATION));
-      }
-      response.status(status).end();
-    }
+    const browserImage = await image.magic(imagePath(params.name), params);
     browserImage.toBuffer(params.type, (err, browserBuffer) => {
       if (err) {
-        response.status(500).end();
+        const status = didTimeout(err) ? 504 : 500;
+        response.status(status).end();
         if (metric) {
-          metric.addTag('status', 200);
+          metric.addTag('status', status);
           metric.stop();
           metrics.write(metric);
           metrics.write(metric.copy(GENERATION));

--- a/src/index.js
+++ b/src/index.js
@@ -212,7 +212,7 @@ const slowShutdown = (expressInstance, timeout = 100) => setTimeout(() => {
   if (statsPrinter) {
     clearInterval(statsPrinter);
   }
-  process.exit(2);
+  database.close().then(() => process.exit(2));
 }, timeout);
 
 database.migrate((err) => {

--- a/src/metrics/console.js
+++ b/src/metrics/console.js
@@ -6,5 +6,4 @@ function setup() {
   };
 }
 
-const instance = setup();
-export default instance;
+export default setup;

--- a/src/metrics/index.js
+++ b/src/metrics/index.js
@@ -36,11 +36,11 @@ function metricsSetup() {
   const metricImplementations = [];
   if (config.has('metrics.influx')) {
     log('info', 'Setting up influx metrics');
-    metricImplementations.push(influx);
+    metricImplementations.push(influx());
   }
   if (config.has('metrics.console')) {
     log('info', 'Setting up console metrics');
-    metricImplementations.push(console);
+    metricImplementations.push(console());
   }
   return {
     write(metric) {

--- a/src/metrics/influx.js
+++ b/src/metrics/influx.js
@@ -30,5 +30,4 @@ function setup() {
   };
 }
 
-const instance = setup();
-export default instance;
+export default setup;


### PR DESCRIPTION
This should ensure that we can keep track of metrics of failing conversions


Flyby: 

- Prevent early instantiation of metrics
- Ensure the system would be properly restarted after a DB crash