### PR TITLE
Properly handle token creation for duplicate tokens

### DIFF
--- a/src/token.js
+++ b/src/token.js
@@ -7,17 +7,17 @@ const shouldRunCleanup = () => Math.floor(Math.random() * 10) === 0;
 
 export default {
   createToken: async (id) => {
-    const newToken = uuid();
     try {
-      await database.createToken(id, newToken);
-      log('info', 'Created token successfully');
+      const newToken = await database.createToken(id, uuid());
+      if (newToken) {
+        log('info', 'Created token successfully');
+      }
       if (shouldRunCleanup()) {
         log('info', 'Running token database cleanup');
         await database.cleanupTokens();
       }
       return newToken;
     } catch (e) {
-      // Duplicate for the id
       log('error', e.stack);
       return null;
     }


### PR DESCRIPTION
In case a token was already created, `token.js` expected an error to be thrown by `database.createToken`, however that function already handles the exception internally, returning an undefined value to indicate no new token has been created. Because of this `token.js` thought the new token was persisted correctly and returned the unpersisted token. Instead it now return the value as provided by `database.createToken`, so `/token` can indicate a proper 403 here.