### PR TITLE
Properly set qualities for webp as well

### DIFF
--- a/src/image.js
+++ b/src/image.js
@@ -129,9 +129,10 @@ const setQuality = async (client, params) => {
 
   // The imagemagick 'quality' parameter has a very different meaning for
   // different image types, so it's not a good idea to just blindly pass it
-  // through. For now, we only support jpg compression, which is the most intuitive.
+  // through. For now, we only support jpg and webp compression, which is the most intuitive.
   switch (params.mime) {
     case 'image/jpeg':
+    case 'image/webp':
       return client.quality(Math.min(100, Math.max(0, params.quality)));
     default:
       //No compression supported for other types


### PR DESCRIPTION
🤦‍♂️ Forgot to set this properly, and obviously I ran my tests locally with quality is 100 but in production I compared a quality 100 to quality of JPG (which was set to a lower value)

