### PR TITLE
Improve restart resiliency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,4 +37,4 @@ RUN convert -version
 
 # Run the entire thing!
 WORKDIR /opt/iaas
-CMD ["/usr/local/bin/pm2", "start", "index.js", "--no-daemon", "--instances=max"]
+CMD ["/usr/local/bin/pm2", "start", "index.js", "--no-daemon", "--instances=max", "--exp-backoff-restart-delay=100"]

--- a/src/databases/postgresql.js
+++ b/src/databases/postgresql.js
@@ -132,12 +132,12 @@ export default function postgresql() {
     return pool.connect((err, client, done) => {
       if (err) {
         log('error', `error fetching client from pool ${err}`);
-        return;
+        callback(err);
       }
       migrateAndStart(client, './migrations', () => {
         log('info', 'Database migrated to newest version');
         done(null);
-        callback();
+        callback(null);
       });
     });
   }

--- a/src/index.js
+++ b/src/index.js
@@ -221,25 +221,25 @@ const slowShutdown = (expressInstance, timeout = 100) => setTimeout(() => {
 
 database.migrate((err) => {
   if (err) {
-    log('error', `Error fetching client from pool: ${err}`);
+    log('error', `Error fetching client from pool for migrations: ${err}`);
     slowShutdown(null, 250);
-  } else {
-    const port = process.env.PORT || 1337; //eslint-disable-line no-process-env
-    const handler = server.listen(port, () => log('info', `Server started listening on port ${port}`));
-    // Sync robots.txt
-    syncRobotsTxt();
-
-    // Log the stats every 5 minutes if enabled
-    statsPrinter = setInterval(() => log('stats', stats.get()), 5 * 60 * 1000);
-    const dbChecker = setInterval(async () => {
-      const isAlive = await database.isDbAlive();
-
-      if (!isAlive) {
-        clearInterval(dbChecker);
-        log('error', 'Database connection went offline! Restarting the application so we can connect to another one');
-        // Slight timeout to handle some final requests?
-        slowShutdown(handler);
-      }
-    }, 500);
+    return;
   }
+  const port = process.env.PORT || 1337; //eslint-disable-line no-process-env
+  const handler = server.listen(port, () => log('info', `Server started listening on port ${port}`));
+  // Sync robots.txt
+  syncRobotsTxt();
+
+  // Log the stats every 5 minutes if enabled
+  statsPrinter = setInterval(() => log('stats', stats.get()), 5 * 60 * 1000);
+  const dbChecker = setInterval(async () => {
+    const isAlive = await database.isDbAlive();
+
+    if (!isAlive) {
+      clearInterval(dbChecker);
+      log('error', 'Database connection went offline! Restarting the application so we can connect to another one');
+      // Slight timeout to handle some final requests?
+      slowShutdown(handler);
+    }
+  }, 500);
 });


### PR DESCRIPTION
When a database failed, upon the first retry the migration would fail, but by not correctly passing the error the system would enter a frozen state. Not serving requests, but not retrying either. By passing the error properly to the callback, this is fixed.

Additionally when running Docker, this adds a retry policy so it keeps retrying with an exponential backoff in order to resume service as soon as possible.

Easiest reviewing with the [`?w=1`](https://github.com/inventid/iaas/pull/127/files?w=1) option

@AlexKolpa @joostverdoorn Ready for review