### PR TITLE
Log database calls timings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.15-jessie
+FROM node:10-stretch
 MAINTAINER Rogier Slag
 
 RUN apt-get update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,10 @@ RUN apt-get update && \
     apt-get autoremove -y && \
     apt-get clean
 
+# Install dumb-init as pm2-docker does not support the backoff restart delay
+RUN wget https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_amd64.deb
+RUN dpkg -i dumb-init_*.deb
+
 RUN yarn global add pm2 babel-cli babel-preset-es2015 babel-preset-stage-3
 
 # Export the database, originals dir and the config dir
@@ -39,4 +43,4 @@ RUN convert -version
 
 # Run the entire thing!
 WORKDIR /opt/iaas
-CMD ["/usr/local/bin/pm2", "start", "index.js", "--no-daemon", "--instances=max", "--exp-backoff-restart-delay=100"]
+CMD ["dumb-init", "/usr/local/bin/pm2", "start", "index.js", "--no-daemon", "--instances=max", "--exp-backoff-restart-delay=100"]

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ The following settings are supported:
 | postgresql.password | PostgresSQL password |
 | postgresql.host | Host on which the database is running |
 | postgres.database | Name of your database |
+| postgresql.pool | The size of the database pool to use |
 | allow_indexing | Whether to allow robots to index the images |
 | constraints.max_width | The maximum allowed width of the image. If a request is made that succeeds this width then a redirect is issued to an equivalent image within bounds. |
 | constraints.max_height | The maximum allowed height of the image. If a request is made that succeeds this height then a redirect is issued to an equivalent image within bounds. |
@@ -189,7 +190,7 @@ On OSX the Docker Toolbox suffices.
 1. After installing the Docker toolbox (which we will use here), you need to create a Docker machine `docker-machine create inventid --driver=virtualbox`
 2. Then define the docker machine `eval $(docker-machine env inventid)`
 3. Ensure you have a PostgreSQL instance available, see the section on _Database_ on how to achieve this
-3. Next (this also applies for Linux) we'll create the container `mkdir -p /tmp/images && docker build --tag=test . && docker run -p 1337:1337 -v /tmp/images:/opt/images -v <YOUR_GIT_REPO_LOCATION>/config:/opt/iaas/config test`
+3. Next (this also applies for Linux) we'll create the container `mkdir -p /tmp/images && docker build --tag=test . && docker run -p 1337:1337 -v /tmp/images:/opt/images -v ``pwd``/config:/opt/iaas/config test`
 4. Now you can start developing. After each change, stop the container (Ctrl-C) and re-execute the command again. Rebuilds of the container are relatively fast.
 
 Quick way to send images (ensure you have `jq` installed)

--- a/src/index.js
+++ b/src/index.js
@@ -271,14 +271,18 @@ database.migrate((err) => {
 
   // Log the stats every 5 minutes if enabled
   statsPrinter = setInterval(() => log('stats', stats.get()), 5 * 60 * 1000);
-  const dbChecker = setInterval(async () => {
-    const isAlive = await database.isDbAlive();
+  const timeoutDelay = Math.floor(Math.random() * 2500);
+  // Delay the checking a bit randomly, as otherwise everyone hugs the connections at the same time
+  setTimeout(() => {
+    const dbChecker = setInterval(async () => {
+      const isAlive = await database.isDbAlive();
 
-    if (!isAlive) {
-      clearInterval(dbChecker);
-      log('error', 'Database connection went offline! Restarting the application so we can connect to another one');
-      // Slight timeout to handle some final requests?
-      slowShutdown(handler);
-    }
-  }, 500);
+      if (!isAlive) {
+        clearInterval(dbChecker);
+        log('error', 'Database connection went offline! Restarting the application so we can connect to another one');
+        // Slight timeout to handle some final requests?
+        slowShutdown(handler);
+      }
+    }, 2500);
+  }, timeoutDelay);
 });

--- a/src/metrics/index.js
+++ b/src/metrics/index.js
@@ -12,8 +12,9 @@ export const UPLOAD_TO_CACHE = 'uploadToCache';
 export const UPLOAD = 'upload';
 export const ORIGINAL = 'original';
 export const REQUEST_TOKEN = 'requestToken';
+export const DATABASE = 'database';
 
-export const VALID_TYPES = [REQUEST, REDIRECT, GENERATION, UPLOAD_TO_CACHE, UPLOAD, ORIGINAL, REQUEST_TOKEN];
+export const VALID_TYPES = [REQUEST, REDIRECT, GENERATION, UPLOAD_TO_CACHE, UPLOAD, ORIGINAL, REQUEST_TOKEN, DATABASE];
 
 export function metricFromParams(params, type = REQUEST) {
   // The -1 handles the case where an original image was requested


### PR DESCRIPTION
We noticed that sometimes database pools got exhausted, leading to really slow generations and uploads. I cannot figure out where exactly, but it seems something in the database is slow, leading to some resource starvation. When we upped the pool size, timings dropped significantly (see images below)

1. This PR adds instrumentation to all database calls
1. It reduces the frequency of checking whether a dababase is alive
1. It adds `dumb-init` so the Docker container closes better
1. Adds missing documentation in the README

**redirect timings**
<img width="730" alt="Screenshot 2019-07-15 at 21 18 03" src="https://user-images.githubusercontent.com/2778689/61242812-f1ee8200-a746-11e9-9636-122706cfed33.png">

**number of database requests waiting for connections**
<img width="354" alt="Screenshot 2019-07-15 at 21 18 10" src="https://user-images.githubusercontent.com/2778689/61242814-f3b84580-a746-11e9-82b6-82a2005cd6ec.png">

'm curious to see whether something is off in the database, or whether some calls are just performing badly